### PR TITLE
fix: Make Pi deployment more robust

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -99,7 +99,9 @@ jobs:
       - name: Update code and restart containers
         run: |
           cd /home/r410/kakeibo-ai
-          git pull origin main
+          # Ensure local changes to tracked files are discarded to avoid pull conflicts
+          git fetch origin main
+          git reset --hard origin/main
           docker compose build
           docker compose up -d
           


### PR DESCRIPTION
## Summary
This PR fixes a deployment failure on the Raspberry Pi caused by local file conflicts during git pull.

### The Issue
On the Raspberry Pi host, some tracked template files (like settings.json.example) appear to have local changes, which causes git pull origin main to fail with a merge conflict.

### The Fix
Updated the deploy job in .github/workflows/ci-cd.yml to use a more robust update strategy:
1.  git fetch origin main: Fetch the latest changes.
2.  git reset --hard origin/main: Forcefully sync the local repository with the remote main branch, discarding any local changes to tracked files.

This ensures that the deployment always starts from a clean, up-to-date state corresponding exactly to the merged code.

### Verification
- Verified the YAML syntax.
- Confirmed that this strategy is standard for automated deployments where the runner environment should not maintain local modifications.