### PR TITLE
fix: Resolve path duplication issue in production

### DIFF
--- a/infra/docker/nginx.conf
+++ b/infra/docker/nginx.conf
@@ -10,7 +10,9 @@ server {
 
     # API Proxy
     location /api/ {
-        proxy_pass http://backend:8000/api/;
+        # backendコンテナの8000番ポート（FastAPI）へプロキシ
+        # /api/status -> http://backend:8000/api/status
+        proxy_pass http://backend:8000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## Summary
This PR fixes the issue where dashboard data was not being displayed due to incorrect API path resolution in the production environment.

### The Issue
Production logs showed requests to /api/api/... resulting in 404 errors. This was caused by the combination of:
1.  **Frontend**: Using relative paths like client.get('/api/status').
2.  **Nginx**: Using proxy_pass http://backend:8000/api/; (with a trailing slash).

In Nginx, if proxy_pass includes a path (even just a /), it replaces the part of the URI matched by the location block. This caused /api/status to be transformed into /api/api/status (or similar duplication) before hitting the backend.

### The Fix
Updated infra/docker/nginx.conf to use proxy_pass http://backend:8000; (without the trailing slash/path).
This ensures that Nginx passes the URI exactly as it was received. Combined with the frontend's use of root-relative paths, the backend will now receive the correct /api/status requests.

### Verification
- This change specifically addresses the 404 errors seen in the user's provided logs.
- Confirmed that the API itself is working via the user's direct URL test.