### PR TITLE
feat: モデル使用量（トークン）の可視化 (#62)

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -55,6 +55,10 @@ export interface AnalysisHistory {
   score: number;
   summary: string;
   report_path: string;
+  model_name?: string;
+  prompt_tokens?: number;
+  response_tokens?: number;
+  total_tokens?: number;
 }
 
 export interface AIModel {

--- a/frontend/src/pages/AIReview.tsx
+++ b/frontend/src/pages/AIReview.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Calendar, FileText, Info, AlertTriangle, AlertCircle, CheckCircle } from 'lucide-react';
+import { Calendar, FileText, Info, AlertTriangle, AlertCircle, CheckCircle, Bot } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import client from '../api/client';
@@ -106,7 +106,15 @@ const AIReview: React.FC = () => {
           <div className="card-body">
             {selectedReview ? (
               <div className="review-full-text">
-                <div className="badge score-good mb-4">Score: {selectedReview.score}</div>
+                <div style={{ display: 'flex', gap: '12px', alignItems: 'center', marginBottom: '16px' }}>
+                  <div className="badge score-good">Score: {selectedReview.score}</div>
+                  {selectedReview.total_tokens && (
+                    <div className="badge" style={{ backgroundColor: 'rgba(0,0,0,0.2)', border: '1px solid var(--border)', color: 'var(--text-muted)' }}>
+                      <Bot size={14} className="inline mr-1" />
+                      {selectedReview.model_name || 'AI Model'} ({selectedReview.total_tokens.toLocaleString()} tokens)
+                    </div>
+                  )}
+                </div>
                 <h4 className="mb-2">要約</h4>
                 <div className="review-summary mb-4">
                   {selectedReview.summary}

--- a/main.py
+++ b/main.py
@@ -170,12 +170,13 @@ def run_review(timeframe: str, source: str = "mf", headless: bool = True, skip_f
         # 3. Slack通知
         if output_slack:
             notifier = SlackNotifier()
-            model_info = f" (Model: {ai_response.model_name})" if ai_response.model_name else ""
             notifier.send_block_kit(
-                title=f"家計簿AIレビュー ({timeframe}){model_info}",
+                title=f"家計簿AIレビュー ({timeframe})",
                 report=ai_response.slack_report,
                 actions=ai_response.actions,
-                score=ai_response.totonoi_score
+                score=ai_response.totonoi_score,
+                model_name=ai_response.model_name,
+                total_tokens=ai_response.total_tokens
             )
             if graph_path:
                 notifier.upload_file(graph_path, f"資産推移グラフ ({timeframe})")

--- a/src/output/slack_notifier.py
+++ b/src/output/slack_notifier.py
@@ -88,7 +88,7 @@ class SlackNotifier:
         except Exception as e:
             print(f"Failed to send simple notification: {e}")
 
-    def send_block_kit(self, title: str, report: str, actions: List[AIAction], score: int):
+    def send_block_kit(self, title: str, report: str, actions: List[AIAction], score: int, model_name: str = None, total_tokens: int = None):
         """
         Slack Web API を使用して DM を送信する
         """
@@ -152,12 +152,18 @@ class SlackNotifier:
         blocks.append({
             "type": "divider"
         })
+        context_text = f"詳細レポートは Obsidian または <{self.dashboard_url}|🌐 Webダッシュボード> でチェックしてね！✨ (v{__version__})"
+        if model_name or total_tokens:
+            token_str = f" / {total_tokens:,} tokens" if total_tokens else ""
+            model_str = model_name or "AI"
+            context_text += f" | 🤖 {model_str}{token_str}"
+
         blocks.append({
             "type": "context",
             "elements": [
                 {
                     "type": "mrkdwn",
-                    "text": f"詳細レポートは Obsidian または <{self.dashboard_url}|🌐 Webダッシュボード> でチェックしてね！✨ (v{__version__})"
+                    "text": context_text
                 }
             ]
         })


### PR DESCRIPTION
AI分析のAPIレスポンスにトークン使用量と推定コスト（トークン数）を含め、AIレビュー画面にバッジで表示するように実装しました。Slackへの返信末尾（コンテキストブロック）にも付与するように修正しました。