### PR TITLE
feat: カテゴリ自動マッピング機能とAI提案機能の実装 (Issue #2)

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { Settings as SettingsIcon, Save, AlertTriangle, Bot, User, Target, Wallet, Code, CheckCircle2 } from 'lucide-react';
+import { Settings as SettingsIcon, Save, AlertTriangle, Bot, User, Target, Wallet, Code, CheckCircle2, ArrowRightLeft, Plus, Trash2 } from 'lucide-react';
 import client from '../api/client';
 import type { AISettings } from '../api/client';
 import TopHeader from '../components/TopHeader';
@@ -7,25 +7,30 @@ import TopHeader from '../components/TopHeader';
 const Settings: React.FC = () => {
   const [budget, setBudget] = useState<any>(null);
   const [profile, setProfile] = useState<any>(null);
+  const [mapping, setMapping] = useState<any>(null);
   const [aiSettings, setAiSettings] = useState<AISettings | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
+  const [suggesting, setSuggesting] = useState(false);
   const [activeMode, setActiveMode] = useState<'ui' | 'json'>('ui');
-  const [activeTab, setActiveTab] = useState<'ai' | 'profile' | 'budget'>('ai');
+  const [activeTab, setActiveTab] = useState<'ai' | 'profile' | 'budget' | 'mapping'>('ai');
   const [message, setMessage] = useState<{ text: string, type: 'success' | 'error' } | null>(null);
   const [confirmModal, setConfirmModal] = useState<{ isOpen: boolean, modelId: string | null }>({ isOpen: false, modelId: null });
+  const [aiSuggestions, setAiSuggestions] = useState<any[]>([]);
 
   // JSON string states for the 'Advanced' tab
   const [budgetJson, setBudgetJson] = useState('');
   const [profileJson, setProfileJson] = useState('');
+  const [mappingJson, setMappingJson] = useState('');
 
   const fetchSettings = async () => {
     setLoading(true);
     try {
-      const [budgetRes, profileRes, aiRes] = await Promise.all([
+      const [budgetRes, profileRes, aiRes, mappingRes] = await Promise.all([
         client.get('/api/settings/budget'),
         client.get('/api/settings/profile'),
-        client.get<AISettings>('/api/settings/ai-models')
+        client.get<AISettings>('/api/settings/ai-models'),
+        client.get('/api/settings/mapping')
       ]);
       
       // 旧形式の budget.json を正規化: monthly.categories → monthly.budget.variable
@@ -49,9 +54,11 @@ const Settings: React.FC = () => {
       setBudget(budgetData);
       setProfile(profileRes.data);
       setAiSettings(aiRes.data);
+      setMapping(mappingRes.data);
       
       setBudgetJson(JSON.stringify(budgetData, null, 2));
       setProfileJson(JSON.stringify(profileRes.data, null, 2));
+      setMappingJson(JSON.stringify(mappingRes.data, null, 2));
     } catch (error) {
       console.error('Failed to fetch settings', error);
     } finally {
@@ -69,19 +76,23 @@ const Settings: React.FC = () => {
     try {
       let finalBudget = budget;
       let finalProfile = profile;
+      let finalMapping = mapping;
 
       if (activeMode === 'json') {
         finalBudget = JSON.parse(budgetJson);
         finalProfile = JSON.parse(profileJson);
+        finalMapping = JSON.parse(mappingJson);
       }
 
       await Promise.all([
         client.put('/api/settings/budget', finalBudget),
-        client.put('/api/settings/profile', finalProfile)
+        client.put('/api/settings/profile', finalProfile),
+        client.put('/api/settings/mapping', finalMapping)
       ]);
       
       setBudget(finalBudget);
       setProfile(finalProfile);
+      setMapping(finalMapping);
       setMessage({ text: '設定を保存しました', type: 'success' });
       setTimeout(() => setMessage(null), 3000);
     } catch (error: any) {
@@ -90,6 +101,42 @@ const Settings: React.FC = () => {
     } finally {
       setSaving(false);
     }
+  };
+
+  const handleSuggestMappings = async () => {
+    setSuggesting(true);
+    try {
+      const res = await client.post('/api/settings/mapping/suggest');
+      setAiSuggestions(res.data);
+      if (res.data.length === 0) {
+        setMessage({ text: '新しいマッピングの提案はありません', type: 'success' });
+      }
+    } catch (error) {
+      setMessage({ text: '提案の取得に失敗しました', type: 'error' });
+    } finally {
+      setSuggesting(false);
+    }
+  };
+
+  const applySuggestion = (s: any) => {
+    const newMapping = { ...mapping };
+    if (s.suggested_category && s.suggested_category !== s.raw_category) {
+      if (!newMapping.category_mappings) newMapping.category_mappings = {};
+      newMapping.category_mappings[s.raw_category] = s.suggested_category;
+    }
+    
+    if (s.suggested_genre && s.suggested_genre !== s.raw_genre) {
+      if (!newMapping.genre_mappings) newMapping.genre_mappings = {};
+      if (s.suggested_category) {
+        newMapping.genre_mappings[s.raw_genre] = { category: s.suggested_category, genre: s.suggested_genre };
+      } else {
+        newMapping.genre_mappings[s.raw_genre] = s.suggested_genre;
+      }
+    }
+    
+    setMapping(newMapping);
+    setMappingJson(JSON.stringify(newMapping, null, 2));
+    setAiSuggestions(prev => prev.filter(item => item !== s));
   };
 
   const handleModelChange = (modelId: string) => {
@@ -221,6 +268,9 @@ const Settings: React.FC = () => {
             </button>
             <button className={`tab-link ${activeTab === 'budget' ? 'active' : ''}`} onClick={() => setActiveTab('budget')}>
               <Wallet size={18} /> 予算設定
+            </button>
+            <button className={`tab-link ${activeTab === 'mapping' ? 'active' : ''}`} onClick={() => setActiveTab('mapping')}>
+              <ArrowRightLeft size={18} /> カテゴリ変換
             </button>
           </div>
         )}
@@ -524,10 +574,264 @@ const Settings: React.FC = () => {
               </div>
               );
             })()}
+
+            {activeTab === 'mapping' && (
+              <div className="flex flex-col gap-6" style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+                <div className="card" style={{ border: '1px solid var(--primary)', background: 'rgba(59, 130, 246, 0.05)' }}>
+                  <div className="card-header" style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                    <h3 style={{ color: 'var(--primary)' }}><Bot size={20} /> AI マッピング提案</h3>
+                    <button 
+                      className="btn-primary" 
+                      onClick={handleSuggestMappings} 
+                      disabled={suggesting}
+                      style={{ padding: '4px 12px', fontSize: '0.85rem' }}
+                    >
+                      {suggesting ? '考え中...' : 'AIにマッピングを相談する'}
+                    </button>
+                  </div>
+                  <div className="card-body">
+                    <p className="text-muted mb-4" style={{ fontSize: '0.85rem' }}>
+                      DB内の未分類項目をスキャンし、予算設定に基づいた最適なマッピングをAIが提案します。
+                    </p>
+                    {aiSuggestions.length > 0 ? (
+                      <div className="flex flex-col gap-3">
+                        {aiSuggestions.map((s, idx) => (
+                          <div key={idx} className="suggestion-item" style={{ background: 'var(--bg-color)', padding: '12px', borderRadius: '8px', border: '1px solid var(--border)', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                            <div style={{ flex: 1 }}>
+                              <div style={{ fontSize: '0.75rem', color: 'var(--text-muted)' }}>
+                                {s.raw_category} {s.raw_genre ? `> ${s.raw_genre}` : ''}
+                              </div>
+                              <div style={{ fontWeight: 'bold', display: 'flex', alignItems: 'center', gap: '8px' }}>
+                                <ArrowRightLeft size={14} className="text-primary" />
+                                {s.suggested_category} {s.suggested_genre ? `> ${s.suggested_genre}` : ''}
+                              </div>
+                              <div style={{ fontSize: '0.7rem', color: 'var(--success)', marginTop: '4px' }}>
+                                理由: {s.reason}
+                              </div>
+                            </div>
+                            <button className="btn-outline" onClick={() => applySuggestion(s)} style={{ padding: '4px 8px', fontSize: '0.75rem' }}>
+                              採用
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    ) : !suggesting && (
+                      <div className="text-center py-4 text-muted" style={{ fontSize: '0.85rem' }}>
+                        「相談する」ボタンを押すと、新しい提案が表示されます。
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                <div className="card">
+                  <div className="card-header">
+                    <h3><ArrowRightLeft size={20} /> 大項目の変換ルール (Category Mapping)</h3>
+                  </div>
+                  <div className="card-body">
+                    <p className="text-muted mb-4" style={{ fontSize: '0.85rem' }}>
+                      MoneyForwardやZaimの「大項目」を、独自のカテゴリ名に変換します。
+                    </p>
+                    <table className="table">
+                      <thead>
+                        <tr>
+                          <th>元のカテゴリ名 (Raw)</th>
+                          <th style={{ width: '40px' }}></th>
+                          <th>変換後のカテゴリ名 (Mapped)</th>
+                          <th style={{ width: '60px' }}></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Object.entries(mapping?.category_mappings || {}).map(([raw, mapped]) => (
+                          <tr key={raw}>
+                            <td>{raw}</td>
+                            <td style={{ textAlign: 'center' }}>→</td>
+                            <td>
+                              <input 
+                                type="text" className="form-control form-control-sm" 
+                                value={mapped as string} 
+                                onChange={(e) => {
+                                  const newMapping = { ...mapping };
+                                  newMapping.category_mappings[raw] = e.target.value;
+                                  setMapping(newMapping);
+                                  setMappingJson(JSON.stringify(newMapping, null, 2));
+                                }}
+                              />
+                            </td>
+                            <td style={{ textAlign: 'center' }}>
+                              <button 
+                                className="btn-icon text-danger" 
+                                onClick={() => {
+                                  const newMapping = { ...mapping };
+                                  delete newMapping.category_mappings[raw];
+                                  setMapping(newMapping);
+                                  setMappingJson(JSON.stringify(newMapping, null, 2));
+                                }}
+                              >
+                                <Trash2 size={16} />
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                        <tr>
+                          <td>
+                            <input type="text" id="new-cat-raw" className="form-control form-control-sm" placeholder="未分類" />
+                          </td>
+                          <td style={{ textAlign: 'center' }}>→</td>
+                          <td>
+                            <input type="text" id="new-cat-mapped" className="form-control form-control-sm" placeholder="その他" />
+                          </td>
+                          <td style={{ textAlign: 'center' }}>
+                            <button 
+                              className="btn-icon text-primary"
+                              onClick={() => {
+                                const raw = (document.getElementById('new-cat-raw') as HTMLInputElement).value;
+                                const mapped = (document.getElementById('new-cat-mapped') as HTMLInputElement).value;
+                                if (raw && mapped) {
+                                  const newMapping = { ...mapping };
+                                  if (!newMapping.category_mappings) newMapping.category_mappings = {};
+                                  newMapping.category_mappings[raw] = mapped;
+                                  setMapping(newMapping);
+                                  setMappingJson(JSON.stringify(newMapping, null, 2));
+                                  (document.getElementById('new-cat-raw') as HTMLInputElement).value = '';
+                                  (document.getElementById('new-cat-mapped') as HTMLInputElement).value = '';
+                                }
+                              }}
+                            >
+                              <Plus size={18} />
+                            </button>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+
+                <div className="card">
+                  <div className="card-header">
+                    <h3><ArrowRightLeft size={20} /> 中項目の変換・上書きルール (Genre Mapping)</h3>
+                  </div>
+                  <div className="card-body">
+                    <p className="text-muted mb-4" style={{ fontSize: '0.85rem' }}>
+                      「中項目」の名前に基づいて、中項目名のみ、または大項目も含めて変換します。<br/>
+                      例: 「コンビニ」という中項目を「日用品」という中項目に変更する、など。
+                    </p>
+                    <table className="table">
+                      <thead>
+                        <tr>
+                          <th>元の中項目名 (Raw)</th>
+                          <th style={{ width: '40px' }}></th>
+                          <th>変換後のカテゴリ/中項目</th>
+                          <th style={{ width: '60px' }}></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {Object.entries(mapping?.genre_mappings || {}).map(([raw, rule]: [string, any]) => (
+                          <tr key={raw}>
+                            <td>{raw}</td>
+                            <td style={{ textAlign: 'center' }}>→</td>
+                            <td>
+                              <div style={{ display: 'flex', gap: '8px' }}>
+                                <div style={{ flex: 1 }}>
+                                  <label style={{ fontSize: '0.7rem' }}>大項目(任意)</label>
+                                  <input 
+                                    type="text" className="form-control form-control-sm" 
+                                    placeholder="大項目"
+                                    value={typeof rule === 'object' ? rule.category : ''} 
+                                    onChange={(e) => {
+                                      const newMapping = { ...mapping };
+                                      if (typeof rule !== 'object') {
+                                        newMapping.genre_mappings[raw] = { category: e.target.value, genre: rule };
+                                      } else {
+                                        newMapping.genre_mappings[raw].category = e.target.value;
+                                      }
+                                      setMapping(newMapping);
+                                      setMappingJson(JSON.stringify(newMapping, null, 2));
+                                    }}
+                                  />
+                                </div>
+                                <div style={{ flex: 1 }}>
+                                  <label style={{ fontSize: '0.7rem' }}>中項目</label>
+                                  <input 
+                                    type="text" className="form-control form-control-sm" 
+                                    placeholder="中項目"
+                                    value={typeof rule === 'object' ? rule.genre : rule} 
+                                    onChange={(e) => {
+                                      const newMapping = { ...mapping };
+                                      if (typeof rule !== 'object') {
+                                        newMapping.genre_mappings[raw] = e.target.value;
+                                      } else {
+                                        newMapping.genre_mappings[raw].genre = e.target.value;
+                                      }
+                                      setMapping(newMapping);
+                                      setMappingJson(JSON.stringify(newMapping, null, 2));
+                                    }}
+                                  />
+                                </div>
+                              </div>
+                            </td>
+                            <td style={{ textAlign: 'center', verticalAlign: 'bottom' }}>
+                              <button 
+                                className="btn-icon text-danger" 
+                                onClick={() => {
+                                  const newMapping = { ...mapping };
+                                  delete newMapping.genre_mappings[raw];
+                                  setMapping(newMapping);
+                                  setMappingJson(JSON.stringify(newMapping, null, 2));
+                                }}
+                              >
+                                <Trash2 size={16} />
+                              </button>
+                            </td>
+                          </tr>
+                        ))}
+                        <tr>
+                          <td>
+                            <input type="text" id="new-gen-raw" className="form-control form-control-sm" placeholder="ランチ" />
+                          </td>
+                          <td style={{ textAlign: 'center' }}>→</td>
+                          <td>
+                            <div style={{ display: 'flex', gap: '8px' }}>
+                              <input type="text" id="new-gen-cat" className="form-control form-control-sm" placeholder="食費(任意)" />
+                              <input type="text" id="new-gen-gen" className="form-control form-control-sm" placeholder="昼食" />
+                            </div>
+                          </td>
+                          <td style={{ textAlign: 'center' }}>
+                            <button 
+                              className="btn-icon text-primary"
+                              onClick={() => {
+                                const raw = (document.getElementById('new-gen-raw') as HTMLInputElement).value;
+                                const cat = (document.getElementById('new-gen-cat') as HTMLInputElement).value;
+                                const gen = (document.getElementById('new-gen-gen') as HTMLInputElement).value;
+                                if (raw && gen) {
+                                  const newMapping = { ...mapping };
+                                  if (!newMapping.genre_mappings) newMapping.genre_mappings = {};
+                                  if (cat) {
+                                    newMapping.genre_mappings[raw] = { category: cat, genre: gen };
+                                  } else {
+                                    newMapping.genre_mappings[raw] = gen;
+                                  }
+                                  setMapping(newMapping);
+                                  setMappingJson(JSON.stringify(newMapping, null, 2));
+                                  (document.getElementById('new-gen-raw') as HTMLInputElement).value = '';
+                                  (document.getElementById('new-gen-cat') as HTMLInputElement).value = '';
+                                  (document.getElementById('new-gen-gen') as HTMLInputElement).value = '';
+                                }
+                              }}
+                            >
+                              <Plus size={18} />
+                            </button>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
         ) : (
           <div className="dashboard-grid" style={{ padding: 0 }}>
-            <div className="card" style={{ gridColumn: 'span 6' }}>
+            <div className="card" style={{ gridColumn: 'span 4' }}>
               <div className="card-header"><h3>budget.json</h3></div>
               <textarea 
                 className="form-control" 
@@ -536,13 +840,22 @@ const Settings: React.FC = () => {
                 onChange={(e) => setBudgetJson(e.target.value)}
               />
             </div>
-            <div className="card" style={{ gridColumn: 'span 6' }}>
+            <div className="card" style={{ gridColumn: 'span 4' }}>
               <div className="card-header"><h3>profile.json</h3></div>
               <textarea 
                 className="form-control" 
                 style={{ height: '500px', fontFamily: 'monospace', fontSize: '12px' }}
                 value={profileJson}
                 onChange={(e) => setProfileJson(e.target.value)}
+              />
+            </div>
+            <div className="card" style={{ gridColumn: 'span 4' }}>
+              <div className="card-header"><h3>mapping.json</h3></div>
+              <textarea 
+                className="form-control" 
+                style={{ height: '500px', fontFamily: 'monospace', fontSize: '12px' }}
+                value={mappingJson}
+                onChange={(e) => setMappingJson(e.target.value)}
               />
             </div>
           </div>

--- a/src/analyzer/gemini_analyzer.py
+++ b/src/analyzer/gemini_analyzer.py
@@ -208,6 +208,41 @@ class GeminiAnalyzer:
             print(f"Error detecting reimbursements: {e}")
             return []
 
+    def suggest_category_mappings(self, unmapped_items: List[dict], target_categories: List[str]) -> List[dict]:
+        """
+        未マッピングの項目に対して、予算カテゴリへのマッピングを提案する
+        """
+        if not unmapped_items or not target_categories:
+            return []
+
+        system_prompt = (
+            "あなたは優秀な家計簿アシスタントです。金融サービスから取得した「元のカテゴリ・中項目」を、"
+            "ユーザーが設定した「予算カテゴリ」のどれに分類すべきか提案してください。\n"
+            "可能な限り正確に分類し、判断がつかない場合は最も近いものを選んでください。\n"
+            "返却は以下のJSON形式のみで行ってください。コードブロックは含めないでください。\n"
+            "{\"suggestions\": [{\"raw_category\": \"元の大項目\", \"raw_genre\": \"元の中項目\", \"suggested_category\": \"予算カテゴリ名\", \"suggested_genre\": \"提案する中項目名\", \"reason\": \"理由\"}]}"
+        )
+
+        user_input = {
+            "unmapped_items": unmapped_items,
+            "target_categories": target_categories
+        }
+
+        try:
+            response = self.client.models.generate_content(
+                model=self.model_name,
+                contents=f"{system_prompt}\n\n対象データ:\n{json.dumps(user_input, ensure_ascii=False)}",
+                config=types.GenerateContentConfig(
+                    response_mime_type="application/json",
+                    temperature=0.1
+                )
+            )
+            result = json.loads(response.text.strip())
+            return result.get("suggestions", [])
+        except Exception as e:
+            print(f"Error suggesting category mappings: {e}")
+            return []
+
     def _load_prompt_file(self, file_path: str) -> str:
         if os.path.exists(file_path):
             with open(file_path, "r", encoding="utf-8") as f:

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -540,6 +540,90 @@ async def update_profile_settings(data: dict):
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+@app.get("/api/settings/mapping")
+async def get_mapping_settings():
+    config_dir = get_config_dir()
+    mapping_path = os.path.join(config_dir, "mapping.json")
+    if os.path.exists(mapping_path):
+        with open(mapping_path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    return {"category_mappings": {}, "genre_mappings": {}}
+
+@app.put("/api/settings/mapping")
+async def update_mapping_settings(data: dict):
+    config_dir = get_config_dir()
+    mapping_path = os.path.join(config_dir, "mapping.json")
+    try:
+        with open(mapping_path, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2, ensure_ascii=False)
+        return {"status": "success"}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@app.post("/api/settings/mapping/suggest")
+async def suggest_mappings():
+    conn = None
+    try:
+        db_path = get_db_path()
+        config_dir = get_config_dir()
+        
+        # 1. 予算カテゴリの取得
+        budget = load_budget(config_dir)
+        if not budget:
+            raise HTTPException(status_code=400, detail="Budget not configured")
+        
+        target_categories = []
+        monthly_budget = budget.get("monthly", {}).get("budget", {})
+        for section in ["fixed", "variable"]:
+            target_categories.extend(monthly_budget.get(section, {}).keys())
+        
+        # 2. 現在のマッピングを取得
+        mapping_path = os.path.join(config_dir, "mapping.json")
+        current_mappings = {"category_mappings": {}, "genre_mappings": {}}
+        if os.path.exists(mapping_path):
+            with open(mapping_path, "r", encoding="utf-8") as f:
+                current_mappings = json.load(f)
+        
+        # 3. DBから未マッピングのユニークな項目を取得
+        conn = sqlite3.connect(db_path)
+        query = "SELECT DISTINCT category, genre FROM transactions"
+        df = pd.read_sql_query(query, conn)
+        
+        unmapped_items = []
+        for _, row in df.iterrows():
+            cat = row['category']
+            gen = row['genre']
+            
+            # マッピング済みかチェック
+            is_mapped = False
+            if cat in current_mappings.get("category_mappings", {}):
+                is_mapped = True
+            if gen in current_mappings.get("genre_mappings", {}):
+                is_mapped = True
+                
+            # 予算カテゴリに直接含まれているかチェック
+            if cat in target_categories:
+                is_mapped = True
+                
+            if not is_mapped:
+                unmapped_items.append({"category": cat, "genre": gen})
+        
+        if not unmapped_items:
+            return []
+            
+        # 4. AIで提案
+        from src.analyzer.gemini_analyzer import GeminiAnalyzer
+        analyzer = GeminiAnalyzer()
+        suggestions = analyzer.suggest_category_mappings(unmapped_items[:20], target_categories) # 一度に20件までに制限
+        
+        return suggestions
+
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        if conn:
+            conn.close()
+
 @app.post("/api/expense-splitter/detect")
 async def detect_reimbursements():
     conn = None

--- a/src/fetcher/moneyforward_fetcher.py
+++ b/src/fetcher/moneyforward_fetcher.py
@@ -8,6 +8,7 @@ from playwright.sync_api import sync_playwright
 from dotenv import load_dotenv
 from src.models import Transaction, Asset
 from src.fetcher.base_fetcher import BaseFetcher
+from src.utils.category_mapper import CategoryMapper
 
 load_dotenv("local/.env")
 
@@ -21,6 +22,7 @@ class MoneyForwardFetcher(BaseFetcher):
         self.password = os.getenv("MF_PASSWORD")
         self.user_data_dir = os.path.join(os.getcwd(), "local/mf_session")
         self.logger = logging.getLogger(__name__)
+        self.mapper = CategoryMapper()
 
     def _login_and_update(self, page, headless: bool):
         self.logger.info("Navigating to sign_in page...")
@@ -313,11 +315,17 @@ class MoneyForwardFetcher(BaseFetcher):
                 self_amount = 0 # デフォルトで全額立替（経費精算待ち）として扱う
                 reimbursement_status = "pending"
 
+            raw_category = str(row[col_major]) if col_major else "未分類"
+            raw_genre = str(row[col_minor]) if col_minor else ""
+            
+            # カテゴリマッピングの適用
+            mapped_category, mapped_genre = self.mapper.apply_mapping(raw_category, raw_genre)
+
             transactions.append(Transaction(
                 transaction_id=str(row[col_id]) if col_id else None,
                 transaction_date=datetime.strptime(str(row[col_date]), "%Y/%m/%d").date(),
-                category=str(row[col_major]) if col_major else "未分類",
-                genre=str(row[col_minor]) if col_minor else "",
+                category=mapped_category,
+                genre=mapped_genre,
                 amount=abs(amount),
                 comment=comment_text,
                 source="MoneyForward",

--- a/src/fetcher/zaim_fetcher.py
+++ b/src/fetcher/zaim_fetcher.py
@@ -5,6 +5,7 @@ from pyzaim import ZaimAPI
 from dotenv import load_dotenv
 from src.models import Transaction, Asset
 from src.fetcher.base_fetcher import BaseFetcher
+from src.utils.category_mapper import CategoryMapper
 
 load_dotenv("local/.env")
 
@@ -21,6 +22,7 @@ class ZaimFetcher(BaseFetcher):
         self.api = ZaimAPI(consumer_id, consumer_secret, access_token, access_token_secret, oauth_verifier=None)
         self.categories = self.api.category()
         self.genres = self.api.genre()
+        self.mapper = CategoryMapper()
 
     def fetch_transactions(self, days: int = 30) -> List[Transaction]:
         today = date.today()
@@ -33,11 +35,17 @@ class ZaimFetcher(BaseFetcher):
         
         transactions = []
         for item in raw_data:
+            raw_category = self._get_category_name(item["category_id"])
+            raw_genre = self._get_genre_name(item["genre_id"])
+            
+            # カテゴリマッピングの適用
+            mapped_category, mapped_genre = self.mapper.apply_mapping(raw_category, raw_genre)
+
             transactions.append(Transaction(
                 transaction_id=str(item["id"]),
                 transaction_date=date.fromisoformat(item["date"]),
-                category=self._get_category_name(item["category_id"]),
-                genre=self._get_genre_name(item["genre_id"]),
+                category=mapped_category,
+                genre=mapped_genre,
                 amount=item["amount"],
                 comment=item["comment"] or "",
                 source="Zaim",

--- a/src/utils/category_mapper.py
+++ b/src/utils/category_mapper.py
@@ -1,0 +1,40 @@
+import json
+import os
+
+class CategoryMapper:
+    def __init__(self, mapping_path="local/config/mapping.json"):
+        self.mapping_path = mapping_path
+        self.mapping = self._load_mapping()
+        
+    def _load_mapping(self):
+        if os.path.exists(self.mapping_path):
+            try:
+                with open(self.mapping_path, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception:
+                pass
+        return {
+            "category_mappings": {},
+            "genre_mappings": {}
+        }
+        
+    def apply_mapping(self, raw_category: str, raw_genre: str):
+        if not self.mapping:
+            return raw_category, raw_genre
+            
+        # 1. Genre-level overrides (highest priority)
+        genre_rules = self.mapping.get("genre_mappings", {})
+        if raw_genre in genre_rules:
+            rule = genre_rules[raw_genre]
+            if isinstance(rule, dict):
+                return rule.get("category", raw_category), rule.get("genre", raw_genre)
+            elif isinstance(rule, str):
+                return raw_category, rule
+            
+        # 2. Category-level overrides
+        cat_rules = self.mapping.get("category_mappings", {})
+        if raw_category in cat_rules:
+            new_cat = cat_rules[raw_category]
+            return new_cat, raw_genre
+            
+        return raw_category, raw_genre

--- a/tests/test_category_mapping_integration.py
+++ b/tests/test_category_mapping_integration.py
@@ -60,31 +60,38 @@ def test_mf_mapping_integration(mock_read_csv, mapping_file):
 
 @patch('src.fetcher.zaim_fetcher.ZaimAPI')
 def test_zaim_mapping_integration(mock_zaim_api, mapping_file):
-    with patch('src.utils.category_mapper.CategoryMapper.__init__', lambda self, path=mapping_file: setattr(self, 'mapping_path', path) or setattr(self, 'mapping', self._load_mapping())):
-        mock_instance = mock_zaim_api.return_value
-        mock_instance.category.return_value = [
-            {'id': 1, 'name': '未分類'},
-            {'id': 2, 'name': '食費'}
-        ]
-        mock_instance.genre.return_value = [
-            {'id': 11, 'name': 'ランチ'},
-            {'id': 12, 'name': 'コンビニ'}
-        ]
-        mock_instance.data.return_value = [
-            {'id': 1, 'date': '2024-01-01', 'category_id': 1, 'genre_id': 0, 'amount': 100, 'mode': 'payment', 'comment': ''},
-            {'id': 2, 'date': '2024-01-02', 'category_id': 2, 'genre_id': 11, 'amount': 200, 'mode': 'payment', 'comment': ''},
-            {'id': 3, 'date': '2024-01-03', 'category_id': 2, 'genre_id': 12, 'amount': 300, 'mode': 'payment', 'comment': ''}
-        ]
-        
-        fetcher = ZaimFetcher()
-        transactions = fetcher.fetch_transactions()
-        
-        # 未分類 -> その他
-        assert transactions[0].category == "その他"
-        
-        # ランチ -> 食費/昼食
-        assert transactions[1].category == "食費"
-        assert transactions[1].genre == "昼食"
-        
-        # コンビニ -> 日用品
-        assert transactions[2].genre == "日用品"
+    env_vars = {
+        "ZAIM_CONSUMER_ID": "test_id",
+        "ZAIM_CONSUMER_SECRET": "test_secret",
+        "ZAIM_ACCESS_TOKEN": "test_token",
+        "ZAIM_ACCESS_TOKEN_SECRET": "test_token_secret"
+    }
+    with patch.dict('os.environ', env_vars):
+        with patch('src.utils.category_mapper.CategoryMapper.__init__', lambda self, path=mapping_file: setattr(self, 'mapping_path', path) or setattr(self, 'mapping', self._load_mapping())):
+            mock_instance = mock_zaim_api.return_value
+            mock_instance.category.return_value = [
+                {'id': 1, 'name': '未分類'},
+                {'id': 2, 'name': '食費'}
+            ]
+            mock_instance.genre.return_value = [
+                {'id': 11, 'name': 'ランチ'},
+                {'id': 12, 'name': 'コンビニ'}
+            ]
+            mock_instance.data.return_value = [
+                {'id': 1, 'date': '2024-01-01', 'category_id': 1, 'genre_id': 0, 'amount': 100, 'mode': 'payment', 'comment': ''},
+                {'id': 2, 'date': '2024-01-02', 'category_id': 2, 'genre_id': 11, 'amount': 200, 'mode': 'payment', 'comment': ''},
+                {'id': 3, 'date': '2024-01-03', 'category_id': 2, 'genre_id': 12, 'amount': 300, 'mode': 'payment', 'comment': ''}
+            ]
+            
+            fetcher = ZaimFetcher()
+            transactions = fetcher.fetch_transactions()
+            
+            # 未分類 -> その他
+            assert transactions[0].category == "その他"
+            
+            # ランチ -> 食費/昼食
+            assert transactions[1].category == "食費"
+            assert transactions[1].genre == "昼食"
+            
+            # コンビニ -> 日用品
+            assert transactions[2].genre == "日用品"

--- a/tests/test_category_mapping_integration.py
+++ b/tests/test_category_mapping_integration.py
@@ -1,0 +1,90 @@
+import pytest
+import os
+import pandas as pd
+import json
+from datetime import date
+from unittest.mock import MagicMock, patch
+from src.fetcher.moneyforward_fetcher import MoneyForwardFetcher
+from src.fetcher.zaim_fetcher import ZaimFetcher
+from src.models import Transaction
+
+@pytest.fixture
+def mapping_file():
+    mapping_data = {
+        "category_mappings": {
+            "未分類": "その他"
+        },
+        "genre_mappings": {
+            "ランチ": {
+                "category": "食費",
+                "genre": "昼食"
+            },
+            "コンビニ": "日用品"
+        }
+    }
+    mapping_path = "local/config/mapping_test.json"
+    os.makedirs(os.path.dirname(mapping_path), exist_ok=True)
+    with open(mapping_path, "w", encoding="utf-8") as f:
+        json.dump(mapping_data, f)
+    yield mapping_path
+    if os.path.exists(mapping_path):
+        os.remove(mapping_path)
+
+@patch('src.fetcher.moneyforward_fetcher.pd.read_csv')
+def test_mf_mapping_integration(mock_read_csv, mapping_file):
+    with patch('src.utils.category_mapper.CategoryMapper.__init__', lambda self, path=mapping_file: setattr(self, 'mapping_path', path) or setattr(self, 'mapping', self._load_mapping())):
+        fetcher = MoneyForwardFetcher()
+        # カラム名の定義（MoneyForwardFetcher内の検索ロジックに合わせる）
+        df = pd.DataFrame({
+            "ID": ["1", "2", "3"],
+            "日付": ["2024/01/01", "2024/01/02", "2024/01/03"],
+            "内容": ["test1", "test2", "test3"],
+            "金額": ["-1000", "-500", "-2000"],
+            "大項目": ["未分類", "食費", "食費"],
+            "中項目": ["", "ランチ", "コンビニ"],
+            "計算対象": ["1", "1", "1"]
+        })
+        mock_read_csv.return_value = df
+        
+        transactions = fetcher._parse_csv("dummy.csv")
+        
+        # 未分類 -> その他 (category mapping)
+        assert transactions[0].category == "その他"
+        
+        # ランチ -> 食費/昼食 (genre mapping with category override)
+        assert transactions[1].category == "食費"
+        assert transactions[1].genre == "昼食"
+        
+        # コンビニ -> 日用品 (genre mapping string style)
+        assert transactions[2].genre == "日用品"
+
+@patch('src.fetcher.zaim_fetcher.ZaimAPI')
+def test_zaim_mapping_integration(mock_zaim_api, mapping_file):
+    with patch('src.utils.category_mapper.CategoryMapper.__init__', lambda self, path=mapping_file: setattr(self, 'mapping_path', path) or setattr(self, 'mapping', self._load_mapping())):
+        mock_instance = mock_zaim_api.return_value
+        mock_instance.category.return_value = [
+            {'id': 1, 'name': '未分類'},
+            {'id': 2, 'name': '食費'}
+        ]
+        mock_instance.genre.return_value = [
+            {'id': 11, 'name': 'ランチ'},
+            {'id': 12, 'name': 'コンビニ'}
+        ]
+        mock_instance.data.return_value = [
+            {'id': 1, 'date': '2024-01-01', 'category_id': 1, 'genre_id': 0, 'amount': 100, 'mode': 'payment', 'comment': ''},
+            {'id': 2, 'date': '2024-01-02', 'category_id': 2, 'genre_id': 11, 'amount': 200, 'mode': 'payment', 'comment': ''},
+            {'id': 3, 'date': '2024-01-03', 'category_id': 2, 'genre_id': 12, 'amount': 300, 'mode': 'payment', 'comment': ''}
+        ]
+        
+        fetcher = ZaimFetcher()
+        transactions = fetcher.fetch_transactions()
+        
+        # 未分類 -> その他
+        assert transactions[0].category == "その他"
+        
+        # ランチ -> 食費/昼食
+        assert transactions[1].category == "食費"
+        assert transactions[1].genre == "昼食"
+        
+        # コンビニ -> 日用品
+        assert transactions[2].genre == "日用品"


### PR DESCRIPTION
### 概要
MoneyForwardやZaimから取得した生のカテゴリ名を、システム独自の予算カテゴリに自動変換する機能を実装しました。また、AIによるマッピングの自動提案機能も追加し、初期設定の負担を軽減しています。

### 主な変更点
- **Backend**:
  - `src/utils/category_mapper.py`: マッピングロジックの中核を実装。
  - `src/fetcher/`: MoneyForward/Zaimの各フェッチャーにマッピングを統合。
  - `src/analyzer/gemini_analyzer.py`: AIによるカテゴリ提案メソッドを追加。
  - `src/api/main.py`: マッピング設定のCRUDおよびAI提案用のエンドポイントを追加。
- **Frontend**:
  - `Settings.tsx`: 「カテゴリ変換」タブを新設。手動マッピング管理UIと、AI提案の確認・採用UIを実装。
- **Infrastructure**:
  - `requirements.txt`: `pyzaim`, `slack-sdk`, `pytest-mock` 等の依存関係を明記。

### 検証結果
- `kakeibo-ai` 環境にて `tools/run_regression.py` を実行し、**全バックエンドテスト(51件)のパス**および**フロントエンドのビルド成功**を確認済み。
- 新規追加した統合テスト `tests/test_category_mapping_integration.py` もパス。

```
=== REGRESSION SUMMARY ===
Backend Tests: PASS
Frontend Build: PASS
```
