### PR TITLE
fix: MoneyForward手動ログインへのフォールバック実装

### DIFF
--- a/src/fetcher/moneyforward_fetcher.py
+++ b/src/fetcher/moneyforward_fetcher.py
@@ -34,16 +34,8 @@ class MoneyForwardFetcher(BaseFetcher):
                 self.logger.warning("--- SETUP MODE --- Please complete login in the browser.")
                 page.wait_for_url("https://moneyforward.com/", timeout=300000)
             else:
-                self.logger.info("Logging in to MoneyForward...")
-                try:
-                    page.fill('input[name="user[email]"]', self.user_id)
-                    page.click('input[type="submit"]')
-                    page.fill('input[name="user[password]"]', self.password)
-                    page.click('input[type="submit"]')
-                    time.sleep(5)
-                except Exception as e:
-                    self.logger.error(f"Auto login failed: {e}")
-                    return False
+                self.logger.warning("Session is invalid or expired. Auto-login is disabled due to Captcha.")
+                return "NEEDS_SETUP"
 
         self.logger.info("Updating financial data...")
         page.goto("https://moneyforward.com/", wait_until="networkidle")
@@ -84,7 +76,29 @@ class MoneyForwardFetcher(BaseFetcher):
             browser_context = self._launch_browser(p, headless)
             page = browser_context.new_page()
             
-            if not self._login_and_update(page, headless):
+            login_result = self._login_and_update(page, headless)
+            if login_result == "NEEDS_SETUP":
+                browser_context.close()
+                self.logger.info("Relaunching browser in non-headless mode for manual login...")
+                browser_context = self._launch_browser(p, headless=False)
+                page = browser_context.new_page()
+                page.goto("https://moneyforward.com/users/sign_in")
+                self.logger.warning("--- SETUP MODE --- Please complete login in the browser.")
+                try:
+                    page.wait_for_url("https://moneyforward.com/", timeout=300000)
+                    self.logger.info("Manual login successful. Restarting headless fetch...")
+                except Exception as e:
+                    self.logger.error(f"Manual login timed out or failed: {e}")
+                    browser_context.close()
+                    return []
+                browser_context.close()
+                
+                # Restart headless
+                browser_context = self._launch_browser(p, headless)
+                page = browser_context.new_page()
+                login_result = self._login_and_update(page, headless)
+                
+            if not login_result or login_result == "NEEDS_SETUP":
                 browser_context.close()
                 return []
 
@@ -128,7 +142,29 @@ class MoneyForwardFetcher(BaseFetcher):
             with sync_playwright() as p:
                 browser_context = self._launch_browser(p, headless)
                 page = browser_context.new_page()
-                if not self._login_and_update(page, headless):
+                login_result = self._login_and_update(page, headless)
+                if login_result == "NEEDS_SETUP":
+                    browser_context.close()
+                    self.logger.info("Relaunching browser in non-headless mode for manual login...")
+                    browser_context = self._launch_browser(p, headless=False)
+                    page = browser_context.new_page()
+                    page.goto("https://moneyforward.com/users/sign_in")
+                    self.logger.warning("--- SETUP MODE --- Please complete login in the browser.")
+                    try:
+                        page.wait_for_url("https://moneyforward.com/", timeout=300000)
+                        self.logger.info("Manual login successful. Restarting headless fetch...")
+                    except Exception as e:
+                        self.logger.error(f"Manual login timed out or failed: {e}")
+                        browser_context.close()
+                        return []
+                    browser_context.close()
+                    
+                    # Restart headless
+                    browser_context = self._launch_browser(p, headless)
+                    page = browser_context.new_page()
+                    login_result = self._login_and_update(page, headless)
+                    
+                if not login_result or login_result == "NEEDS_SETUP":
                     browser_context.close()
                     return []
                 result = self._download_csv_direct(page, year, month)
@@ -163,7 +199,29 @@ class MoneyForwardFetcher(BaseFetcher):
             browser_context = self._launch_browser(p, headless)
             page = browser_context.new_page()
             
-            if not self._login_and_update(page, headless):
+            login_result = self._login_and_update(page, headless)
+            if login_result == "NEEDS_SETUP":
+                browser_context.close()
+                self.logger.info("Relaunching browser in non-headless mode for manual login...")
+                browser_context = self._launch_browser(p, headless=False)
+                page = browser_context.new_page()
+                page.goto("https://moneyforward.com/users/sign_in")
+                self.logger.warning("--- SETUP MODE --- Please complete login in the browser.")
+                try:
+                    page.wait_for_url("https://moneyforward.com/", timeout=300000)
+                    self.logger.info("Manual login successful. Restarting headless fetch...")
+                except Exception as e:
+                    self.logger.error(f"Manual login timed out or failed: {e}")
+                    browser_context.close()
+                    return []
+                browser_context.close()
+                
+                # Restart headless
+                browser_context = self._launch_browser(p, headless)
+                page = browser_context.new_page()
+                login_result = self._login_and_update(page, headless)
+                
+            if not login_result or login_result == "NEEDS_SETUP":
                 browser_context.close()
                 return []
 
@@ -269,7 +327,29 @@ class MoneyForwardFetcher(BaseFetcher):
             page = browser_context.pages[0]
             
             # ログイン状態を確認
-            if not self._login_and_update(page, headless):
+            login_result = self._login_and_update(page, headless)
+            if login_result == "NEEDS_SETUP":
+                browser_context.close()
+                self.logger.info("Relaunching browser in non-headless mode for manual login...")
+                browser_context = self._launch_browser(p, headless=False)
+                page = browser_context.pages[0]
+                page.goto("https://moneyforward.com/users/sign_in")
+                self.logger.warning("--- SETUP MODE --- Please complete login in the browser.")
+                try:
+                    page.wait_for_url("https://moneyforward.com/", timeout=300000)
+                    self.logger.info("Manual login successful. Restarting headless fetch...")
+                except Exception as e:
+                    self.logger.error(f"Manual login timed out or failed: {e}")
+                    browser_context.close()
+                    return {}
+                browser_context.close()
+                
+                # Restart headless
+                browser_context = self._launch_browser(p, headless)
+                page = browser_context.pages[0]
+                login_result = self._login_and_update(page, headless)
+                
+            if not login_result or login_result == "NEEDS_SETUP":
                 browser_context.close()
                 return {}
 

--- a/tests/test_fetchers.py
+++ b/tests/test_fetchers.py
@@ -41,7 +41,8 @@ def test_mf_login_success(mock_playwright, mock_mf_env):
     fetcher = MoneyForwardFetcher()
     _, _, mock_page = setup_mock_playwright(mock_playwright)
     
-    mock_page.url = "https://moneyforward.com/users/sign_in"
+    # Session is valid
+    mock_page.url = "https://moneyforward.com/"
     mock_update_btn = MagicMock()
     mock_update_btn.is_visible.return_value = True
     mock_page.locator.return_value.first = mock_update_btn
@@ -51,14 +52,15 @@ def test_mf_login_success(mock_playwright, mock_mf_env):
     assert result is True
 
 @patch('src.fetcher.moneyforward_fetcher.sync_playwright')
-def test_mf_login_fail(mock_playwright, mock_mf_env):
+def test_mf_needs_setup_when_headless(mock_playwright, mock_mf_env):
     fetcher = MoneyForwardFetcher()
     _, _, mock_page = setup_mock_playwright(mock_playwright)
+    
+    # Session is invalid
     mock_page.url = "https://moneyforward.com/users/sign_in"
-    mock_page.fill.side_effect = Exception("Login Error")
     
     result = fetcher._login_and_update(mock_page, headless=True)
-    assert result is False
+    assert result == "NEEDS_SETUP"
 
 @patch('src.fetcher.moneyforward_fetcher.sync_playwright')
 def test_mf_fetch_transactions(mock_playwright, mock_mf_env):


### PR DESCRIPTION
## 概要
MoneyForwardのログイン画面でのreCAPTCHA等により、ヘッドレスでの自動ログイン（ID/PW自動入力）が失敗する問題に対応するため、セッションが無効な場合は自動的にブラウザを非ヘッドレスモードで起動し、ユーザーの手動ログインを待機してセッションを保存する仕組みに変更しました。

## テスト結果
`python tools/cli.py qa regression` をパスしています。

```
=== REGRESSION SUMMARY ===
Backend Tests: PASS (56 passed)
Frontend Build: PASS

Total Duration: 22.78 seconds
✅ ALL CHECKS PASSED. Ready to commit/merge!
```