### PR TITLE
feat(dashboard): fix month selection, improve performance, and add weekly filtering

### DIFF
--- a/.spec/dashboard-fix/intake.md
+++ b/.spec/dashboard-fix/intake.md
@@ -1,0 +1,57 @@
+# Intake: Dashboard Fix (Month Selection & Performance)
+
+## PR target branch
+staging
+
+## Raw prompt
+ダッシュボードに以下の不具合があるので修正してください。
+・右上の月を選択してもその月のデータが表示されない(例えば5月を選んだ場合はその月の実績が表示されるハズ)
+・画面を開くのに時間がかかる(原因はなんですか？)
+
+User clarification:
+- Q1.ヘッダ部の選択肢は削除してください。予実管理のところは週次と月次を切り替え可能にしてください。
+　予実管理で週次を選択した際は勝敗表示を選択することでその週の予実にアクセスできるようにしてください。
+- Q2.そのように修正してください。AIのコンテキスト浪費にもつながるので。 (Refers to moving AI detection out of main load)
+- Q3.ありません
+
+## Clarifications (Q&A)
+### Q1 — Feature behavior: Timeframe selection and navigation
+**Recommended:** Remove timeframe from header. Keep it local to Budget management.
+**User answered:** Agreed. Remove header timeframe. Budget management should be switchable between weekly and monthly. Clicking win/loss in WeeklyForm should update the budget view for that week.
+
+### Q2 — Performance: AI Detection bottleneck
+**Recommended:** Remove AI detection from initial dashboard load to improve performance.
+**User answered:** Agreed. This also saves AI context/tokens.
+
+### Q3 — Reference files:
+**Recommended:** `src/api/routers/dashboard.py` and `frontend/src/pages/Dashboard.tsx`.
+**User answered:** None others.
+
+## Confirmed feature behavior
+- **Inputs:** `month` (YYYY-MM) query parameter for all dashboard-related backend endpoints.
+- **KPI Endpoint:** Should filter by `month` and `timeframe`.
+- **Budget-Actual Endpoint:** Should filter by `month` and `timeframe`.
+- **Cash Flow (Sankey) Endpoint:** Should filter by `month`.
+- **Performance:** `expense-splitter/detect` is moved to a separate loading state or triggered after main data load.
+- **UI Changes:**
+  - Header timeframe selector removed.
+  - `BudgetPacemaker` gets its own timeframe selector (Weekly/Monthly).
+  - `WeeklyForm` items are clickable to filter `BudgetPacemaker` by that specific week.
+  - Selected `month` from `MonthSelector` is applied to all relevant API calls.
+
+## Reference Files (confirmed by user)
+- `src/api/routers/dashboard.py` — Gold Standard for dashboard API.
+- `frontend/src/pages/Dashboard.tsx` — Gold Standard for dashboard UI.
+- `frontend/src/api/client.ts` — API client and type definitions.
+
+## Architecture constraints (confirmed)
+- Backend: FastAPI/SQLite using existing patterns.
+- Frontend: React with Lucide icons.
+- Avoid blocking initial page load with slow AI requests.
+
+## Reuse (do NOT recreate)
+- `src/api/utils.py` — for DB and budget utility functions.
+
+## Unverified assumptions (RISK)
+- "Accessing that week's budget" via `WeeklyForm` assumes we will update the `BudgetPacemaker` view to show data for the specific week corresponding to the clicked icon.
+- Backend support for arbitrary week filtering needs to be implemented or refined in `get_budget_actual`.

--- a/.spec/dashboard-fix/scope.md
+++ b/.spec/dashboard-fix/scope.md
@@ -1,0 +1,48 @@
+# Scope: Dashboard Fix (Month Selection & Performance)
+
+## Objective
+Enable users to accurately view and manage their household budget by fixing month selection synchronization and improving dashboard performance by decoupling slow AI detection.
+
+## User stories
+- As a user, I want the dashboard to display data for the selected month so that I can track my expenses accurately.
+- As a user, I want the dashboard to load quickly so that I don't have to wait to see my financial status.
+- As a user, I want to switch between weekly and monthly budget views in the budget management section so that I can analyze my spending at different granularities.
+- As a user, I want to click on weekly performance icons to view details for that specific week so that I can quickly investigate budget deviations.
+
+## Acceptance criteria
+- [ ] Removes the timeframe selector from the global dashboard header.
+- [ ] Displays data for the month selected in the `MonthSelector` across all dashboard components (KPIs, Budget-Actual, Sankey).
+- [ ] Implements a timeframe selector (Weekly/Monthly) within the `BudgetPacemaker` component.
+- [ ] Updates the `BudgetPacemaker` view to filter by a specific week when a win/loss icon is clicked in the `WeeklyForm`.
+- [ ] Decouples AI expense detection from the initial dashboard load to ensure immediate visibility of core financial data.
+- [ ] Backend endpoints (`kpi`, `budget-actual`, `cash-flow`) correctly handle `month` and `timeframe` query parameters.
+- [ ] Frontend API calls include the correctly selected `month` and `timeframe` parameters.
+
+## External Tools & Design Mocks
+- Figma: none
+- Other Tools: none
+
+## Reference Files (Gold Standards)
+- src/api/routers/dashboard.py — Gold Standard for dashboard API.
+- frontend/src/pages/Dashboard.tsx — Gold Standard for dashboard UI.
+- frontend/src/api/client.ts — API client and type definitions.
+
+## Architecture constraints
+- Backend: FastAPI/SQLite using existing patterns.
+- Frontend: React with Lucide icons.
+- Avoid blocking initial page load with slow AI requests.
+
+## Reuse (do NOT recreate)
+- src/api/utils.py — for DB and budget utility functions.
+
+## Out of scope
+- Implementation of new AI detection models.
+- Modification of data import or fetching logic.
+- Changes to the main navigation menu outside of the dashboard header.
+
+## Unverified assumptions (RISK)
+- "Accessing that week's budget" via `WeeklyForm` assumes we will update the `BudgetPacemaker` view to show data for the specific week corresponding to the clicked icon.
+- Backend support for arbitrary week filtering needs to be implemented or refined in `get_budget_actual`.
+
+## Context
+The dashboard currently suffers from synchronization issues where the month selector does not correctly filter all components, leading to confusing data displays. Additionally, slow AI detection processes are blocking the initial page load, degrading user experience. This update focuses on fixing these synchronization bugs and optimizing the critical rendering path for better performance.

--- a/conductor/dashboard-fix-plan.md
+++ b/conductor/dashboard-fix-plan.md
@@ -1,0 +1,39 @@
+# Dashboard Fixes Implementation Plan
+
+## Objective
+Fix the dashboard month selection bug and improve initial loading performance. Remove the global timeframe selector and implement localized timeframe/week switching for the budget management section.
+
+## Scope & Impact
+- **Backend (`src/api/routers/dashboard.py`, `src/api/routers/analysis.py`)**: Update endpoints to filter data based on the provided `month` and `week` parameters. Include budget `section` metadata.
+- **Frontend (`frontend/src/pages/Dashboard.tsx`, `frontend/src/components/...`)**: Remove global timeframe tabs. Localize timeframe state to the Budget components. Decouple slow AI reimbursement detection from the initial data load to improve perceived performance. Link the Weekly win/loss form to budget views.
+
+## Proposed Solution (Design)
+1. **Backend Parameterization**: Ensure `get_kpi`, `get_budget_actual`, `get_stats_flow`, and `get_weekly_form` accurately respect the `month` parameter.
+2. **AI Decoupling**: Move the `/api/expense-splitter/detect` API call out of the initial `Promise.all` block in `Dashboard.tsx`. Fetch it asynchronously after core financial data renders.
+3. **Localized Timeframe Control**: Remove the timeframe prop from `TopHeader`. Add it directly to `BudgetPacemaker`.
+4. **Data-driven Sections**: Update the `budget-actual` API to return category section (fixed/variable) metadata to remove hardcoded UI lists.
+
+## Implementation Steps
+
+### Task 1: Backend API Enhancement
+- Update `src/api/routers/dashboard.py` to support historical data retrieval via `month` query parameter for KPI, Budget-Actual, and Stats Flow endpoints.
+- Ensure `get_budget_actual` can filter by a specific `week`.
+- Update `get_budget_actual` response to include the `section` (fixed/variable) field based on the loaded budget configuration.
+
+### Task 2: Frontend Dashboard State & Sync
+- In `frontend/src/pages/Dashboard.tsx`, ensure `MonthSelector` changes trigger a re-fetch of all relevant data for that specific month.
+- Remove the timeframe selector from `TopHeader`.
+- Update the filtering logic for `variableExpenses` and `fixedExpenses` to use the new `section` field from the API instead of a hardcoded list.
+
+### Task 3: Weekly View Filtering
+- In `frontend/src/components/WeeklyForm.tsx`, add click handlers to the week icons (W/L/D).
+- In `frontend/src/pages/Dashboard.tsx`, pass a callback to `WeeklyForm` to update a new `selectedWeek` state when clicked. Trigger a re-fetch of `BudgetActual` data for that specific week and update the `BudgetPacemaker` view.
+
+### Task 4: Performance Optimization
+- In `frontend/src/pages/Dashboard.tsx`, remove the `expense-splitter/detect` POST request from the main `fetchData` function's `Promise.all`.
+- Create a separate `useEffect` or background function to fetch the AI reimbursement suggestions after the main data has loaded, updating the `reimbursementSuggestions` state independently.
+
+## Verification & Testing
+- Run `pytest tests/test_dashboard_api.py` to ensure backend parameter filtering works.
+- Run `npm run build` in `frontend/` to verify TypeScript types and build success.
+- End-to-end manual verification in the browser to ensure month switching works, performance is improved, and weekly filtering functions correctly.

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -38,9 +38,16 @@ export interface KPI {
 
 export interface BudgetActual {
   category: string;
+  section: 'fixed' | 'variable';
   budget: number;
   actual: number;
   pace_limit?: number;
+}
+
+export interface WeeklyFormItem {
+  status: 'W' | 'L' | 'D';
+  start_date: string;
+  end_date: string;
 }
 
 export interface SankeyNode {

--- a/frontend/src/components/WeeklyForm.tsx
+++ b/frontend/src/components/WeeklyForm.tsx
@@ -1,69 +1,82 @@
 import React from 'react';
+import type { WeeklyFormItem } from '../api/client';
 
 interface WeeklyFormProps {
-  history: string[]; // e.g. ["W", "L", "W", "W"]
+  history: WeeklyFormItem[];
+  selectedWeek?: string;
+  onWeekClick?: (startDate: string) => void;
 }
 
-const WeeklyForm: React.FC<WeeklyFormProps> = ({ history }) => {
+const WeeklyForm: React.FC<WeeklyFormProps> = ({ history, selectedWeek, onWeekClick }) => {
   if (!history || history.length === 0) {
     return null;
   }
 
+  // API returns [3 weeks ago, 2 weeks ago, 1 week ago, current week]
+  // We want to show them in chronological order? Or as is?
+  // Previous code showed index 0 as "Current".
+  // Looking at src/api/routers/analysis.py: i in range(3, -1, -1) -> [3, 2, 1, 0]
+  // So results[0] is 3 weeks ago, results[3] is current week.
+  
   return (
     <div className="flex items-center gap-2">
       <span className="text-[10px] font-black text-slate-500 mr-3 uppercase tracking-[0.2em]">Weekly Form:</span>
       <div className="flex gap-2">
-        {history.map((result, index) => {
-          const isCurrent = index === 0;
+        {history.map((item, index) => {
+          const isCurrent = index === history.length - 1;
+          const isSelected = selectedWeek === item.start_date;
+          const result = item.status;
+
           let bgColor = 'rgba(255, 255, 255, 0.05)';
           let textColor = '#64748b'; // slate-500
-          let borderColor = 'transparent';
+          let borderColor = isSelected ? 'rgba(255, 255, 255, 0.5)' : 'transparent';
           let shadow = 'none';
 
           if (result === 'W') {
             bgColor = 'rgba(16, 185, 129, 0.1)';
             textColor = '#34d399'; // emerald-400
-            if (isCurrent) {
+            if (isCurrent || isSelected) {
               borderColor = '#10b981'; // emerald-500
-              shadow = '0 0 12px rgba(16, 185, 129, 0.4)';
+              shadow = isSelected ? '0 0 16px rgba(16, 185, 129, 0.6)' : '0 0 12px rgba(16, 185, 129, 0.4)';
             }
           } else if (result === 'L') {
             bgColor = 'rgba(239, 68, 68, 0.1)';
             textColor = '#f87171'; // red-400
-            if (isCurrent) {
+            if (isCurrent || isSelected) {
               borderColor = '#ef4444'; // red-500
-              shadow = '0 0 12px rgba(239, 68, 68, 0.4)';
+              shadow = isSelected ? '0 0 16px rgba(239, 68, 68, 0.6)' : '0 0 12px rgba(239, 68, 68, 0.4)';
             }
           } else if (result === 'D') {
             bgColor = 'rgba(245, 158, 11, 0.1)';
             textColor = '#fbbf24'; // amber-400
-            if (isCurrent) {
+            if (isCurrent || isSelected) {
               borderColor = '#f59e0b'; // amber-500
-              shadow = '0 0 12px rgba(245, 158, 11, 0.4)';
+              shadow = isSelected ? '0 0 16px rgba(245, 158, 11, 0.6)' : '0 0 12px rgba(245, 158, 11, 0.4)';
             }
           }
 
           return (
-            <div 
+            <button 
               key={index}
-              className={`w-9 h-9 rounded-lg flex items-center justify-center font-black text-xs border-2 transition-all duration-300 relative`}
+              onClick={() => onWeekClick?.(item.start_date)}
+              className={`w-9 h-9 rounded-lg flex items-center justify-center font-black text-xs border-2 transition-all duration-300 relative hover:scale-110 active:scale-95`}
               style={{ 
                 backgroundColor: bgColor, 
                 color: textColor, 
                 borderColor: borderColor,
                 boxShadow: shadow,
-                opacity: isCurrent ? 1 : 0.4
+                opacity: isCurrent || isSelected ? 1 : 0.4
               }}
-              title={isCurrent ? "今週" : `${index}週前`}
+              title={`${item.start_date} ~ ${item.end_date}`}
             >
               {result}
-              {isCurrent && (
+              {isCurrent && !isSelected && (
                 <span className="absolute -top-1 -right-1 flex h-2 w-2">
                   <span className="animate-ping absolute inline-flex h-full w-full rounded-full opacity-75" style={{ backgroundColor: borderColor }}></span>
                   <span className="relative inline-flex rounded-full h-2 w-2" style={{ backgroundColor: borderColor }}></span>
                 </span>
               )}
-            </div>
+            </button>
           );
         })}
       </div>

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ExternalLink, Wallet, Handshake, List, Sparkles } from 'lucide-react';
 import client from '../api/client';
-import type { KPI, BudgetActual, AssetTrend, SankeyData, LatestSummary, Transaction, ReimbursementSuggestion } from '../api/client';
+import type { KPI, BudgetActual, AssetTrend, SankeyData, LatestSummary, Transaction, ReimbursementSuggestion, WeeklyFormItem } from '../api/client';
 import AssetPieChart from '../components/AssetPieChart';
 import MonthSelector from '../components/MonthSelector';
 import SankeyChart from '../components/SankeyChart';
@@ -17,35 +17,36 @@ const Dashboard: React.FC = () => {
   const [assetTrend, setAssetTrend] = useState<AssetTrend[]>([]);
   const [sankeyData, setSankeyData] = useState<SankeyData | null>(null);
   const [latestSummary, setLatestSummary] = useState<string>('');
-  const [weeklyForm, setWeeklyForm] = useState<string[]>([]);
+  const [weeklyForm, setWeeklyForm] = useState<WeeklyFormItem[]>([]);
   const [transactions, setTransactions] = useState<Transaction[]>([]);
   const [pendingReimbursements, setPendingReimbursements] = useState<any[]>([]);
   const [reimbursementSuggestions, setReimbursementSuggestions] = useState<ReimbursementSuggestion[]>([]);
   
   const [loading, setLoading] = useState(true);
+  const [detectLoading, setDetectLoading] = useState(false);
   const [timeframe, setTimeframe] = useState('monthly');
+  const [selectedWeek, setSelectedWeek] = useState<string | undefined>(undefined);
   const [currentMonth, setCurrentMonth] = useState(() => {
     const now = new Date();
     return `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
   });
 
-  const fetchData = async () => {
-    setLoading(true);
+  const fetchData = useCallback(async (isSilent = false) => {
+    if (!isSilent) setLoading(true);
     try {
       const [
         kpiRes, baRes, assetRes, 
         sankeyRes, summaryRes, formRes, 
-        txRes, pendingRes, detectRes
+        txRes, pendingRes
       ] = await Promise.all([
         client.get<KPI>(`/api/kpi?timeframe=${timeframe}&month=${currentMonth}`),
-        client.get<BudgetActual[]>(`/api/budget-actual?timeframe=${timeframe}`),
+        client.get<BudgetActual[]>(`/api/budget-actual?timeframe=${timeframe}&month=${currentMonth}${selectedWeek ? `&week=${selectedWeek}` : ''}`),
         client.get<AssetTrend[]>('/api/assets'),
-        client.get<SankeyData>('/api/stats/flow'),
+        client.get<SankeyData>(`/api/stats/flow?month=${currentMonth}`),
         client.get<LatestSummary>('/api/analysis-history/latest-summary'),
-        client.get<string[]>('/api/analysis-history/form'),
+        client.get<WeeklyFormItem[]>(`/api/analysis-history/form?month=${currentMonth}`),
         client.get<Transaction[]>('/api/transactions?limit=10'),
-        client.get<any[]>('/api/reimbursements/pending'),
-        client.post<ReimbursementSuggestion[]>('/api/expense-splitter/detect')
+        client.get<any[]>('/api/reimbursements/pending')
       ]);
 
       setKpi(kpiRes.data);
@@ -56,24 +57,48 @@ const Dashboard: React.FC = () => {
       setWeeklyForm(formRes.data);
       setTransactions(txRes.data);
       setPendingReimbursements(pendingRes.data);
-      setReimbursementSuggestions(detectRes.data);
     } catch (error) {
       console.error('Failed to fetch dashboard data', error);
     } finally {
-      setLoading(false);
+      if (!isSilent) setLoading(false);
     }
-  };
+  }, [timeframe, currentMonth, selectedWeek]);
+
+  const fetchAIContent = useCallback(async () => {
+    setDetectLoading(true);
+    try {
+      const detectRes = await client.post<ReimbursementSuggestion[]>('/api/expense-splitter/detect');
+      setReimbursementSuggestions(detectRes.data);
+    } catch (error) {
+      console.error('Failed to fetch AI suggestions', error);
+    } finally {
+      setDetectLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
     fetchData();
-  }, [timeframe, currentMonth]);
+  }, [fetchData]);
 
-  // 固定費と変動費を分離 (現状のAPIレスポンスにis_fixedフラグがないため簡易分類)
-  const fixedCategories = ['家賃', '光熱費', '通信費', '保険'];
-  const variableExpenses = budgetActual.filter(item => !fixedCategories.includes(item.category));
-  const fixedExpenses = budgetActual.filter(item => fixedCategories.includes(item.category));
+  useEffect(() => {
+    fetchAIContent();
+  }, [fetchAIContent]);
+
+  // APIの'section'フィールドを使用して固定費と変動費を分離
+  const variableExpenses = budgetActual.filter(item => item.section === 'variable');
+  const fixedExpenses = budgetActual.filter(item => item.section === 'fixed');
 
   const pendingTotal = pendingReimbursements.reduce((sum, item) => sum + (item.pending_amount || 0), 0);
+
+  const handleWeekClick = (startDate: string) => {
+    setTimeframe('weekly');
+    setSelectedWeek(startDate);
+  };
+
+  const handleMonthChange = (newMonth: string) => {
+    setCurrentMonth(newMonth);
+    setSelectedWeek(undefined); // 月が変わったら週選択をクリア
+  };
 
   if (loading && !kpi) {
     return (
@@ -87,17 +112,14 @@ const Dashboard: React.FC = () => {
     <>
       <TopHeader 
         title="ダッシュボード" 
-        onRefresh={fetchData} 
-        timeframes={['daily', 'weekly', 'monthly', 'yearly']}
-        activeTimeframe={timeframe}
-        onTimeframeChange={setTimeframe}
+        onRefresh={() => fetchData(false)} 
         loading={loading}
       />
 
       <div className="max-w-[1400px] mx-auto px-4 sm:px-6 py-8 md:py-12 text-slate-100">
         <div className="flex flex-col sm:flex-row justify-between items-start sm:items-end mb-8 md:mb-16 gap-4">
           <h2 className="text-2xl font-bold tracking-tight text-slate-400">Overview</h2>
-          <MonthSelector currentMonth={currentMonth} onChange={setCurrentMonth} />
+          <MonthSelector currentMonth={currentMonth} onChange={handleMonthChange} />
         </div>
 
         {/* Overview Section */}
@@ -115,7 +137,7 @@ const Dashboard: React.FC = () => {
               <span className="text-4xl sm:text-5xl md:text-6xl font-black text-slate-100 tracking-tighter transition-all">
                 ¥{Math.round((kpi?.actual ?? 0) / Math.max(1, new Date().getDate())).toLocaleString()}
               </span>
-              <span className="text-sm text-slate-500 font-bold mt-2">Current Month</span>
+              <span className="text-sm text-slate-500 font-bold mt-2">Selected Month</span>
             </div>
             <div className="flex flex-col">
               <span className="text-xs uppercase tracking-widest text-slate-500 font-bold mb-2">Kakeibo Score</span>
@@ -165,11 +187,18 @@ const Dashboard: React.FC = () => {
             </div>
             <div>
               <div className="mb-8 md:mb-12">
-                <WeeklyForm history={weeklyForm} />
+                <WeeklyForm 
+                  history={weeklyForm} 
+                  selectedWeek={selectedWeek}
+                  onWeekClick={handleWeekClick}
+                />
               </div>
               <BudgetPacemaker 
                 timeframe={timeframe} 
-                onTimeframeChange={setTimeframe} 
+                onTimeframeChange={(tf) => {
+                  setTimeframe(tf);
+                  if (tf !== 'weekly') setSelectedWeek(undefined);
+                }} 
                 variableExpenses={variableExpenses} 
                 fixedExpenses={fixedExpenses} 
               />
@@ -254,6 +283,7 @@ const Dashboard: React.FC = () => {
               <div className="flex items-center gap-3 mb-8">
                 <Sparkles className="text-amber-400" size={20} />
                 <h4 className="text-lg font-bold">AI 立替検知</h4>
+                {detectLoading && <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-amber-400"></div>}
               </div>
               
               <div className="space-y-2">
@@ -281,7 +311,7 @@ const Dashboard: React.FC = () => {
                   })
                 ) : (
                   <div className="text-slate-600 text-sm font-medium text-center py-10 bg-slate-900/20 rounded-lg border border-dashed border-slate-800">
-                    新しい立替候補は見つかりませんでした
+                    {detectLoading ? "立替候補をスキャン中..." : "新しい立替候補は見つかりませんでした"}
                   </div>
                 )}
               </div>

--- a/frontend/src/test/Dashboard.test.tsx
+++ b/frontend/src/test/Dashboard.test.tsx
@@ -36,8 +36,8 @@ describe('Dashboard Component', () => {
       }
       if (url.includes('/api/budget-actual')) {
         return Promise.resolve({ data: [
-          { category: '食費', budget: 60000, actual: 45000, pace_limit: 50000 },
-          { category: '家賃', budget: 80000, actual: 80000, pace_limit: 80000 }
+          { category: '食費', section: 'variable', budget: 60000, actual: 45000, pace_limit: 50000 },
+          { category: '家賃', section: 'fixed', budget: 80000, actual: 80000, pace_limit: 80000 }
         ] });
       }
       if (url.includes('/api/assets')) {
@@ -50,7 +50,12 @@ describe('Dashboard Component', () => {
         return Promise.resolve({ data: { summary: "順調です。" } });
       }
       if (url.includes('/api/analysis-history/form')) {
-        return Promise.resolve({ data: ["W", "L", "W", "W"] });
+        return Promise.resolve({ data: [
+          { status: "W", start_date: "2026-05-11", end_date: "2026-05-17" },
+          { status: "L", start_date: "2026-05-18", end_date: "2026-05-24" },
+          { status: "W", start_date: "2026-05-25", end_date: "2026-05-31" },
+          { status: "W", start_date: "2026-06-01", end_date: "2026-06-07" }
+        ] });
       }
       if (url.includes('/api/transactions')) {
         return Promise.resolve({ data: [] });

--- a/src/api/routers/analysis.py
+++ b/src/api/routers/analysis.py
@@ -75,9 +75,9 @@ async def get_latest_summary():
             conn.close()
 
 @router.get("/analysis-history/form")
-async def get_weekly_form():
+async def get_weekly_form(month: Optional[str] = None):
     """
-    直近4週間の予算達成状況（勝敗データ）を取得。
+    指定月、または直近の予算達成状況（勝敗データ）を取得。
     W: 実績 <= 予算, L: 実績 > 予算
     """
     conn = None
@@ -93,30 +93,53 @@ async def get_weekly_form():
         
         conn = sqlite3.connect(db_path)
         now = datetime.now()
+        
+        if month:
+            try:
+                # 指定月の末日を基準にする
+                ref_date = datetime.strptime(month, "%Y-%m")
+                if ref_date.month == 12:
+                    next_month = datetime(ref_date.year + 1, 1, 1)
+                else:
+                    next_month = datetime(ref_date.year, ref_date.month + 1, 1)
+                last_day_of_month = next_month - timedelta(days=1)
+                base_date = last_day_of_month
+                # 指定月が未来の場合は現在日に制限
+                if base_date > now:
+                    base_date = now
+            except:
+                base_date = now
+        else:
+            base_date = now
+
         results = []
         
-        # 直近4週間（今週を含む）
+        # 基準日から遡って4週間
         for i in range(3, -1, -1):
-            start_date = now - timedelta(days=now.weekday() + 7 * i)
+            # 週の月曜日を計算
+            start_date = base_date - timedelta(days=base_date.weekday() + 7 * i)
             end_date = start_date + timedelta(days=6)
             
             query = "SELECT SUM(CASE WHEN is_reimbursement=1 AND self_amount IS NOT NULL THEN self_amount ELSE amount END) as total FROM transactions WHERE transaction_date BETWEEN ? AND ? AND mode='payment'"
             actual = pd.read_sql_query(query, conn, params=(start_date.strftime("%Y-%m-%d"), end_date.strftime("%Y-%m-%d")))['total'].iloc[0]
             actual = int(actual) if pd.notnull(actual) else 0
             
-            if i == 0:
-                # 今週は進行中なので Pace Limit で判定
+            # 進行中の週（本日を含む週）かどうかの判定
+            is_current_week = start_date <= now <= end_date
+            
+            if is_current_week:
+                # 進行中なので Pace Limit で判定
                 days_elapsed = (now - start_date).days + 1
                 current_pace_budget = (weekly_budget / 7) * days_elapsed
-                if actual <= current_pace_budget:
-                    results.append("W")
-                else:
-                    results.append("L")
+                status = "W" if actual <= current_pace_budget else "L"
             else:
-                if actual <= weekly_budget:
-                    results.append("W")
-                else:
-                    results.append("L")
+                status = "W" if actual <= weekly_budget else "L"
+            
+            results.append({
+                "status": status,
+                "start_date": start_date.strftime("%Y-%m-%d"),
+                "end_date": end_date.strftime("%Y-%m-%d")
+            })
                     
         return results
     except Exception as e:

--- a/src/api/routers/dashboard.py
+++ b/src/api/routers/dashboard.py
@@ -3,6 +3,7 @@ import os
 import sqlite3
 import pandas as pd
 from datetime import datetime, timedelta
+from typing import Optional, List
 from src.db.database import Database
 from src.api.utils import get_db_path, get_config_dir, load_budget, get_budget_category_totals
 
@@ -41,7 +42,7 @@ async def get_status():
         }
 
 @router.get("/kpi")
-async def get_kpi(timeframe: str = "monthly"):
+async def get_kpi(timeframe: str = "monthly", month: Optional[str] = None):
     conn = None
     try:
         db_path = get_db_path()
@@ -51,20 +52,29 @@ async def get_kpi(timeframe: str = "monthly"):
         total_budget = sum(budget_categories.values()) if budget_categories else 0
         
         now = datetime.now()
+        if month:
+            try:
+                ref_date = datetime.strptime(month, "%Y-%m")
+            except:
+                ref_date = now
+        else:
+            ref_date = now
+
         if timeframe == "daily":
-            date_pattern = now.strftime("%Y-%m-%d")
+            date_pattern = ref_date.strftime("%Y-%m-%d")
         elif timeframe == "weekly":
-            monday = now - timedelta(days=now.weekday())
+            monday = ref_date - timedelta(days=ref_date.weekday())
             date_pattern = None
         else:
-            date_pattern = now.strftime("%Y-%m")
+            date_pattern = ref_date.strftime("%Y-%m")
         
         conn = sqlite3.connect(db_path)
         
         if timeframe == "weekly":
-            monday = now - timedelta(days=now.weekday())
+            monday = ref_date - timedelta(days=ref_date.weekday())
+            sunday = monday + timedelta(days=6)
             query_total = "SELECT SUM(CASE WHEN is_reimbursement=1 AND self_amount IS NOT NULL THEN self_amount ELSE amount END) as total FROM transactions WHERE transaction_date BETWEEN ? AND ? AND mode='payment'"
-            actual_total = pd.read_sql_query(query_total, conn, params=(monday.strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d")))['total'].iloc[0]
+            actual_total = pd.read_sql_query(query_total, conn, params=(monday.strftime("%Y-%m-%d"), sunday.strftime("%Y-%m-%d")))['total'].iloc[0]
         else:
             query_total = "SELECT SUM(CASE WHEN is_reimbursement=1 AND self_amount IS NOT NULL THEN self_amount ELSE amount END) as total FROM transactions WHERE transaction_date LIKE ? AND mode='payment'"
             actual_total = pd.read_sql_query(query_total, conn, params=(f"{date_pattern}%",))['total'].iloc[0]
@@ -89,7 +99,7 @@ async def get_kpi(timeframe: str = "monthly"):
             conn.close()
 
 @router.get("/budget-actual")
-async def get_budget_actual(timeframe: str = "monthly"):
+async def get_budget_actual(timeframe: str = "monthly", month: Optional[str] = None, week: Optional[str] = None):
     conn = None
     try:
         db_path = get_db_path()
@@ -100,44 +110,97 @@ async def get_budget_actual(timeframe: str = "monthly"):
             return []
             
         now = datetime.now()
-        
+        if month:
+            try:
+                ref_date = datetime.strptime(month, "%Y-%m")
+            except:
+                ref_date = now
+        else:
+            ref_date = now
+
         # timeframeに応じた期間と予算倍率の設定
-        if timeframe == "weekly":
-            start_date = now - timedelta(days=now.weekday()) # Monday
+        if week and timeframe == "weekly":
+            try:
+                start_date = datetime.strptime(week, "%Y-%m-%d")
+                end_date = start_date + timedelta(days=6)
+                days_in_period = 7
+                # もし未来の週なら全日経過として扱うか、現在週なら本日まで
+                if start_date <= now <= end_date:
+                    days_elapsed = (now - start_date).days + 1
+                elif now < start_date:
+                    days_elapsed = 0
+                else:
+                    days_elapsed = 7
+                multiplier = 7 / 30.44
+            except:
+                start_date = now - timedelta(days=now.weekday())
+                end_date = start_date + timedelta(days=6)
+                days_in_period = 7
+                days_elapsed = (now - start_date).days + 1
+                multiplier = 7 / 30.44
+        elif timeframe == "weekly":
+            start_date = ref_date - timedelta(days=ref_date.weekday()) # Monday
             end_date = start_date + timedelta(days=6)
             days_in_period = 7
-            days_elapsed = (now - start_date).days + 1
-            multiplier = 7 / 30.44 # 平均的な月の日数で按分
-        elif timeframe == "quarterly":
-            quarter = (now.month - 1) // 3 + 1
-            start_date = datetime(now.year, 3 * quarter - 2, 1)
-            if quarter == 4:
-                end_date = datetime(now.year, 12, 31)
+            if start_date <= now <= end_date:
+                days_elapsed = (now - start_date).days + 1
+            elif now < start_date:
+                days_elapsed = 0
             else:
-                end_date = datetime(now.year, 3 * quarter + 1, 1) - timedelta(days=1)
+                days_elapsed = 7
+            multiplier = 7 / 30.44
+        elif timeframe == "quarterly":
+            quarter = (ref_date.month - 1) // 3 + 1
+            start_date = datetime(ref_date.year, 3 * quarter - 2, 1)
+            if quarter == 4:
+                end_date = datetime(ref_date.year, 12, 31)
+            else:
+                end_date = datetime(ref_date.year, 3 * quarter + 1, 1) - timedelta(days=1)
             days_in_period = (end_date - start_date).days + 1
-            days_elapsed = (now - start_date).days + 1
+            if start_date <= now <= end_date:
+                days_elapsed = (now - start_date).days + 1
+            elif now < start_date:
+                days_elapsed = 0
+            else:
+                days_elapsed = days_in_period
             multiplier = 3.0
         elif timeframe == "yearly":
-            start_date = datetime(now.year, 1, 1)
-            end_date = datetime(now.year, 12, 31)
-            days_in_period = 365 if now.year % 4 != 0 else 366
-            days_elapsed = (now - start_date).days + 1
+            start_date = datetime(ref_date.year, 1, 1)
+            end_date = datetime(ref_date.year, 12, 31)
+            days_in_period = 365 if ref_date.year % 4 != 0 else 366
+            if start_date <= now <= end_date:
+                days_elapsed = (now - start_date).days + 1
+            elif now < start_date:
+                days_elapsed = 0
+            else:
+                days_elapsed = days_in_period
             multiplier = 12.0
         else: # monthly
-            start_date = datetime(now.year, now.month, 1)
-            if now.month == 12:
-                end_date = datetime(now.year, 12, 31)
+            start_date = datetime(ref_date.year, ref_date.month, 1)
+            if ref_date.month == 12:
+                end_date = datetime(ref_date.year, 12, 31)
             else:
-                end_date = datetime(now.year, now.month + 1, 1) - timedelta(days=1)
+                end_date = datetime(ref_date.year, ref_date.month + 1, 1) - timedelta(days=1)
             days_in_period = (end_date - start_date).days + 1
-            days_elapsed = now.day
+            if start_date <= now <= end_date:
+                days_elapsed = now.day
+            elif now < start_date:
+                days_elapsed = 0
+            else:
+                days_elapsed = days_in_period
             multiplier = 1.0
 
         conn = sqlite3.connect(db_path)
         query = "SELECT category, SUM(CASE WHEN is_reimbursement=1 AND self_amount IS NOT NULL THEN self_amount ELSE amount END) as actual FROM transactions WHERE transaction_date BETWEEN ? AND ? AND mode='payment' GROUP BY category"
-        df_actual = pd.read_sql_query(query, conn, params=(start_date.strftime("%Y-%m-%d"), now.strftime("%Y-%m-%d")))
+        df_actual = pd.read_sql_query(query, conn, params=(start_date.strftime("%Y-%m-%d"), end_date.strftime("%Y-%m-%d")))
         
+        # 予算設定からセクション情報を取得
+        monthly_budget_config = budget.get("monthly", {}).get("budget", {}) if budget else {}
+        cat_to_section = {}
+        for section in ["fixed", "variable"]:
+            for cat in monthly_budget_config.get(section, {}).keys():
+                cat_to_section[cat] = section
+
         result = []
         for cat, b_amt in budget_categories.items():
             actual_row = df_actual[df_actual['category'] == cat]
@@ -146,10 +209,11 @@ async def get_budget_actual(timeframe: str = "monthly"):
             # 期間に応じた予算額の計算
             adjusted_budget = int(b_amt * multiplier)
             # Pace Limit (理想的な進捗ライン) の計算
-            pace_limit = int((adjusted_budget / days_in_period) * days_elapsed)
+            pace_limit = int((adjusted_budget / days_in_period) * days_elapsed) if days_in_period > 0 else 0
             
             result.append({
                 "category": cat,
+                "section": cat_to_section.get(cat, "variable"),
                 "budget": adjusted_budget,
                 "actual": a_amt,
                 "pace_limit": pace_limit
@@ -162,7 +226,7 @@ async def get_budget_actual(timeframe: str = "monthly"):
             conn.close()
 
 @router.get("/stats/flow")
-async def get_stats_flow():
+async def get_stats_flow(month: Optional[str] = None):
     """
     Sankey Diagram用の多階層フローデータを生成。
     収入源 → 総収入 → カテゴリ(固定/変動) → 詳細カテゴリ
@@ -173,7 +237,7 @@ async def get_stats_flow():
         config_dir = get_config_dir()
         budget = load_budget(config_dir)
         
-        current_month = datetime.now().strftime("%Y-%m")
+        current_month = month if month else datetime.now().strftime("%Y-%m")
         conn = sqlite3.connect(db_path)
         
         # 1. 収入源の取得

--- a/tests/test_dashboard_api.py
+++ b/tests/test_dashboard_api.py
@@ -128,4 +128,7 @@ def test_get_analysis_history_form(mock_db_and_budget):
     data = response.json()
     assert isinstance(data, list)
     assert len(data) > 0
-    assert all(res in ["W", "L", "D", "-"] for res in data)
+    assert all(isinstance(item, dict) for item in data)
+    assert all("status" in item for item in data)
+    assert all("start_date" in item for item in data)
+    assert all(item["status"] in ["W", "L", "D", "-"] for item in data)


### PR DESCRIPTION
## Objective
Fix the dashboard month selection bug and improve initial loading performance. Remove the global timeframe selector and implement localized timeframe/week switching for the budget management section.

## Changes
- **Backend**:
  - Updated `/api/kpi`, `/api/budget-actual`, and `/api/stats/flow` to handle `month` parameter.
  - Updated `/api/budget-actual` to handle `week` parameter and return budget `section` (fixed/variable).
  - Updated `/api/analysis-history/form` to return week dates for frontend filtering.
- **Frontend**:
  - Synchronized dashboard state with `MonthSelector`.
  - Decoupled AI reimbursement detection from initial load for better performance.
  - Removed global timeframe tabs from `TopHeader`.
  - Implemented week-click filtering in `WeeklyForm` linked to `BudgetPacemaker`.
- **Tests**:
  - Updated backend and frontend tests to match new API response structures.

## Verification
- `./venv/bin/python tools/cli.py qa regression` passed (All 64 backend tests and all 13 frontend tests passed).
- Manual verification in browser.
