### PR TITLE
ci: add frontend unit tests to validate job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,10 +45,15 @@ jobs:
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
 
-    - name: Build Check (Frontend)
+    - name: Run Unit Tests (Frontend)
       run: |
         cd frontend
         npm install
+        npm run test -- --run
+
+    - name: Build Check (Frontend)
+      run: |
+        cd frontend
         npm run build
 
   # 2. Deployment (mainブランチへのマージ時のみ実行)


### PR DESCRIPTION
## Summary
- CIの `validate` ジョブに `npm run test -- --run` を追加し、フロントエンドのユニットテストをPR/マージ前に自動実行するよう統合
- 既存の `npm run build` より前に実行することで、テスト失敗時にビルドを無駄に実行しない

## Test plan
- [ ] CI上でフロントエンドテスト（5ファイル・13件）がパスすることを確認
- [ ] バックエンドテストと合わせてvalidateジョブが正常完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)