### PR TITLE
feat(api): add TTL cache for dashboard aggregation endpoints

### DIFF
--- a/src/api/cache.py
+++ b/src/api/cache.py
@@ -1,0 +1,34 @@
+import time
+from typing import Any, Optional
+
+_DEFAULT_TTL = 300  # 5 minutes
+
+
+class TTLCache:
+    def __init__(self, ttl_seconds: int = _DEFAULT_TTL):
+        self._store: dict[str, tuple[Any, float]] = {}
+        self.ttl = ttl_seconds
+
+    def get(self, key: str) -> Optional[Any]:
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+        value, ts = entry
+        if time.monotonic() - ts < self.ttl:
+            return value
+        del self._store[key]
+        return None
+
+    def set(self, key: str, value: Any) -> None:
+        self._store[key] = (value, time.monotonic())
+
+    def invalidate_prefix(self, prefix: str) -> None:
+        for key in [k for k in self._store if k.startswith(prefix)]:
+            del self._store[key]
+
+    def clear(self) -> None:
+        self._store.clear()
+
+
+# Module-level singleton shared across all routers
+dashboard_cache = TTLCache(ttl_seconds=300)

--- a/src/api/routers/dashboard.py
+++ b/src/api/routers/dashboard.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from typing import Optional, List
 from src.db.database import Database
 from src.api.utils import get_db_path, get_config_dir, load_budget, get_budget_category_totals
+from src.api.cache import dashboard_cache
 
 router = APIRouter(prefix="/api", tags=["dashboard"])
 
@@ -43,6 +44,11 @@ async def get_status():
 
 @router.get("/kpi")
 async def get_kpi(timeframe: str = "monthly", month: Optional[str] = None):
+    cache_key = f"kpi:{timeframe}:{month or 'current'}"
+    cached = dashboard_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     conn = None
     try:
         db_path = get_db_path()
@@ -50,7 +56,7 @@ async def get_kpi(timeframe: str = "monthly", month: Optional[str] = None):
         budget = load_budget(config_dir)
         budget_categories = get_budget_category_totals(budget)
         total_budget = sum(budget_categories.values()) if budget_categories else 0
-        
+
         now = datetime.now()
         if month:
             try:
@@ -67,9 +73,9 @@ async def get_kpi(timeframe: str = "monthly", month: Optional[str] = None):
             date_pattern = None
         else:
             date_pattern = ref_date.strftime("%Y-%m")
-        
+
         conn = sqlite3.connect(db_path)
-        
+
         if timeframe == "weekly":
             monday = ref_date - timedelta(days=ref_date.weekday())
             sunday = monday + timedelta(days=6)
@@ -78,19 +84,21 @@ async def get_kpi(timeframe: str = "monthly", month: Optional[str] = None):
         else:
             query_total = "SELECT SUM(CASE WHEN is_reimbursement=1 AND self_amount IS NOT NULL THEN self_amount ELSE amount END) as total FROM transactions WHERE transaction_date LIKE ? AND mode='payment'"
             actual_total = pd.read_sql_query(query_total, conn, params=(f"{date_pattern}%",))['total'].iloc[0]
-        
+
         actual_total = int(actual_total) if pd.notnull(actual_total) else 0
 
         query_assets = "SELECT SUM(amount) as total FROM assets WHERE acquired_date = (SELECT MAX(acquired_date) FROM assets)"
         total_assets = pd.read_sql_query(query_assets, conn)['total'].iloc[0]
         total_assets = int(total_assets) if pd.notnull(total_assets) else 0
 
-        return {
+        result = {
             "budget": total_budget,
             "actual": actual_total,
             "remaining": max(0, total_budget - actual_total),
             "total_assets": total_assets
         }
+        dashboard_cache.set(cache_key, result)
+        return result
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -100,6 +108,11 @@ async def get_kpi(timeframe: str = "monthly", month: Optional[str] = None):
 
 @router.get("/budget-actual")
 async def get_budget_actual(timeframe: str = "monthly", month: Optional[str] = None, week: Optional[str] = None):
+    cache_key = f"budget-actual:{timeframe}:{month or 'current'}:{week or ''}"
+    cached = dashboard_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     conn = None
     try:
         db_path = get_db_path()
@@ -205,12 +218,10 @@ async def get_budget_actual(timeframe: str = "monthly", month: Optional[str] = N
         for cat, b_amt in budget_categories.items():
             actual_row = df_actual[df_actual['category'] == cat]
             a_amt = int(actual_row['actual'].iloc[0]) if not actual_row.empty else 0
-            
-            # 期間に応じた予算額の計算
+
             adjusted_budget = int(b_amt * multiplier)
-            # Pace Limit (理想的な進捗ライン) の計算
             pace_limit = int((adjusted_budget / days_in_period) * days_elapsed) if days_in_period > 0 else 0
-            
+
             result.append({
                 "category": cat,
                 "section": cat_to_section.get(cat, "variable"),
@@ -218,6 +229,7 @@ async def get_budget_actual(timeframe: str = "monthly", month: Optional[str] = N
                 "actual": a_amt,
                 "pace_limit": pace_limit
             })
+        dashboard_cache.set(cache_key, result)
         return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -231,13 +243,17 @@ async def get_stats_flow(month: Optional[str] = None):
     Sankey Diagram用の多階層フローデータを生成。
     収入源 → 総収入 → カテゴリ(固定/変動) → 詳細カテゴリ
     """
+    current_month = month if month else datetime.now().strftime("%Y-%m")
+    cache_key = f"stats-flow:{current_month}"
+    cached = dashboard_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     conn = None
     try:
         db_path = get_db_path()
         config_dir = get_config_dir()
         budget = load_budget(config_dir)
-        
-        current_month = month if month else datetime.now().strftime("%Y-%m")
         conn = sqlite3.connect(db_path)
         
         # 1. 収入源の取得 (Moneyforwardなどのアグリゲーターを特定ラベルにマッピングするため、category/genreも取得)
@@ -330,7 +346,9 @@ async def get_stats_flow(month: Optional[str] = None):
             savings_node = add_node("余剰金(繰り越し)")
             links.append({"source": total_income_node, "target": savings_node, "value": savings})
 
-        return {"nodes": nodes, "links": links}
+        result = {"nodes": nodes, "links": links}
+        dashboard_cache.set(cache_key, result)
+        return result
 
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -340,6 +358,11 @@ async def get_stats_flow(month: Optional[str] = None):
 
 @router.get("/assets")
 async def get_assets():
+    cache_key = "assets"
+    cached = dashboard_cache.get(cache_key)
+    if cached is not None:
+        return cached
+
     conn = None
     try:
         db_path = get_db_path()
@@ -352,7 +375,9 @@ async def get_assets():
         """
         df = pd.read_sql_query(query, conn)
         from src.api.utils import df_to_json_safe_dict
-        return df_to_json_safe_dict(df)
+        result = df_to_json_safe_dict(df)
+        dashboard_cache.set(cache_key, result)
+        return result
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
     finally:

--- a/src/api/routers/transactions.py
+++ b/src/api/routers/transactions.py
@@ -6,6 +6,7 @@ from typing import Optional, List
 from pydantic import BaseModel
 from src.models import Transaction as TransactionModel
 from src.api.utils import get_db_path, get_config_dir, load_budget, df_to_json_safe_dict
+from src.api.cache import dashboard_cache
 
 router = APIRouter(prefix="/api", tags=["transactions"])
 
@@ -76,6 +77,7 @@ async def create_transaction(transaction: TransactionModel):
             transaction.reimbursement_status
         ))
         conn.commit()
+        dashboard_cache.clear()
         return {"status": "success", "transaction_id": transaction.transaction_id}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
@@ -102,6 +104,7 @@ async def update_transaction(transaction_id: str, update: TransactionUpdate):
         query = f"UPDATE transactions SET {', '.join(fields)} WHERE transaction_id = ?"
         cursor.execute(query, values)
         conn.commit()
+        dashboard_cache.clear()
         return {"status": "success"}
     except HTTPException:
         raise
@@ -122,6 +125,7 @@ async def delete_transaction(transaction_id: str):
         if cursor.rowcount == 0:
             raise HTTPException(status_code=404, detail="Transaction not found")
         conn.commit()
+        dashboard_cache.clear()
         return {"status": "success"}
     except HTTPException:
         raise
@@ -191,6 +195,8 @@ async def import_transactions_csv(files: list[UploadFile] = File(...)):
                 os.remove(temp_path)
         except Exception as e:
             errors.append({"file": file.filename, "status": "error", "reason": str(e)})
+    if total_imported > 0:
+        dashboard_cache.clear()
     return {
         "status": "success" if not errors else "partial_success",
         "total_files": len(files),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,14 @@ def mock_kakeibo_analyzer(monkeypatch):
     
     return mock_instance
 
+@pytest.fixture(autouse=True)
+def clear_dashboard_cache():
+    """テスト間のキャッシュ汚染を防ぐ。"""
+    from src.api.cache import dashboard_cache
+    dashboard_cache.clear()
+    yield
+    dashboard_cache.clear()
+
 @pytest.fixture
 def mock_db(tmp_path):
     """

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,50 @@
+import time
+import pytest
+from src.api.cache import TTLCache
+
+
+def test_cache_set_and_get():
+    cache = TTLCache(ttl_seconds=60)
+    cache.set("key1", {"value": 42})
+    assert cache.get("key1") == {"value": 42}
+
+
+def test_cache_miss_returns_none():
+    cache = TTLCache(ttl_seconds=60)
+    assert cache.get("nonexistent") is None
+
+
+def test_cache_expires_after_ttl():
+    cache = TTLCache(ttl_seconds=0)
+    cache.set("key1", "data")
+    # TTL=0 so the entry expires immediately on next access
+    time.sleep(0.01)
+    assert cache.get("key1") is None
+
+
+def test_cache_invalidate_prefix():
+    cache = TTLCache(ttl_seconds=60)
+    cache.set("kpi:monthly:current", 100)
+    cache.set("kpi:weekly:current", 50)
+    cache.set("budget-actual:monthly:current:", 200)
+
+    cache.invalidate_prefix("kpi:")
+    assert cache.get("kpi:monthly:current") is None
+    assert cache.get("kpi:weekly:current") is None
+    assert cache.get("budget-actual:monthly:current:") == 200
+
+
+def test_cache_clear():
+    cache = TTLCache(ttl_seconds=60)
+    cache.set("a", 1)
+    cache.set("b", 2)
+    cache.clear()
+    assert cache.get("a") is None
+    assert cache.get("b") is None
+
+
+def test_cache_overwrite():
+    cache = TTLCache(ttl_seconds=60)
+    cache.set("key", "old")
+    cache.set("key", "new")
+    assert cache.get("key") == "new"


### PR DESCRIPTION
## Summary
- `src/api/cache.py` に5分TTLのインメモリキャッシュ (`TTLCache`) を実装
- `/api/kpi`, `/api/budget-actual`, `/api/stats/flow`, `/api/assets` の重い集計エンドポイントにキャッシュを適用
- トランザクション書き込み（POST/PUT/DELETE）と CSV インポート時にキャッシュを自動無効化
- テスト間のキャッシュ汚染を防ぐ `clear_dashboard_cache` フィクスチャを conftest に追加
- `tests/test_cache.py` でキャッシュロジック（set/get/expire/invalidate/clear）を単体テスト

## Test plan
- [ ] バックエンドテスト全78件がパスすること
- [ ] ダッシュボードのレスポンスが初回より2回目以降で高速化されること（DB クエリ省略）
- [ ] トランザクションを追加・更新・削除後にキャッシュが無効化されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)