### PR TITLE
feat(ai-review): add model usage chart to AI Review page

### DIFF
--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -113,3 +113,12 @@ export interface ReimbursementSuggestion {
   transaction_id: string;
   reason: string;
 }
+
+export interface UsageStat {
+  month: string;
+  model: string;
+  count: number;
+  total_tokens: number;
+  prompt_tokens: number;
+  response_tokens: number;
+}

--- a/frontend/src/pages/AIReview.tsx
+++ b/frontend/src/pages/AIReview.tsx
@@ -2,8 +2,21 @@ import React, { useEffect, useState } from 'react';
 import { Info, AlertTriangle, AlertCircle, CheckCircle, Bot, ChevronRight } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from 'recharts';
 import client from '../api/client';
-import type { AnalysisHistory } from '../api/client';
+import type { AnalysisHistory, UsageStat } from '../api/client';
+
+// モデル別の固定カラーパレット
+const MODEL_COLORS: Record<string, string> = {
+  'gemini-2.0-flash': '#6366f1',
+  'gemini-1.5-flash': '#8b5cf6',
+  'gemini-1.5-pro': '#a78bfa',
+  'gemini-2.5-flash': '#4f46e5',
+  'unknown': '#475569',
+};
+const fallbackColors = ['#06b6d4', '#10b981', '#f59e0b', '#ef4444'];
+const getModelColor = (model: string, index: number) =>
+  MODEL_COLORS[model] ?? fallbackColors[index % fallbackColors.length];
 
 const AIReview: React.FC = () => {
   const [history, setHistory] = useState<AnalysisHistory[]>([]);
@@ -11,6 +24,7 @@ const AIReview: React.FC = () => {
   const [reportContent, setReportContent] = useState<string>('');
   const [loading, setLoading] = useState(true);
   const [timeframe, setTimeframe] = useState('monthly');
+  const [usageStats, setUsageStats] = useState<UsageStat[]>([]);
 
   const fetchHistory = async () => {
     setLoading(true);
@@ -51,8 +65,26 @@ const AIReview: React.FC = () => {
     }
   }, [selectedId]);
 
+  useEffect(() => {
+    client.get<UsageStat[]>('/api/analysis-history/usage-stats?months=6')
+      .then(res => setUsageStats(res.data))
+      .catch(() => {});
+  }, []);
+
   const selectedReview = history.find(h => h.id === selectedId);
   const pastReviews = history.filter(h => h.id !== selectedId);
+
+  // 月別チャート用にピボット変換（モデルを列方向に展開）
+  const models = [...new Set(usageStats.map(s => s.model))];
+  const months = [...new Set(usageStats.map(s => s.month))].sort();
+  const chartData = months.map(month => {
+    const row: Record<string, string | number> = { month };
+    models.forEach(model => {
+      const entry = usageStats.find(s => s.month === month && s.model === model);
+      row[model] = entry ? entry.total_tokens : 0;
+    });
+    return row;
+  });
 
   return (
     <div className="max-w-[1100px] mx-auto px-8 py-12 min-h-screen text-slate-100">
@@ -81,6 +113,42 @@ const AIReview: React.FC = () => {
         </div>
       ) : (
         <>
+          {/* Model Usage Chart */}
+          {usageStats.length > 0 && (
+            <section className="mb-20">
+              <h2 className="text-lg font-black mb-10 flex items-center gap-4 text-slate-500 uppercase tracking-widest">
+                Model Usage
+                <div className="flex-1 h-px bg-slate-800"></div>
+              </h2>
+              <div className="bg-slate-900/50 rounded-3xl p-8 border border-slate-800">
+                <div className="flex items-center justify-between mb-6">
+                  <p className="text-sm text-slate-400">直近6ヶ月のモデル別トークン使用量</p>
+                  <div className="flex items-center gap-3 text-xs text-slate-500">
+                    <span>合計: {usageStats.reduce((s, r) => s + r.total_tokens, 0).toLocaleString()} tokens</span>
+                    <span>•</span>
+                    <span>分析数: {usageStats.reduce((s, r) => s + r.count, 0)} 件</span>
+                  </div>
+                </div>
+                <ResponsiveContainer width="100%" height={240}>
+                  <BarChart data={chartData} margin={{ top: 4, right: 16, left: 0, bottom: 0 }}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#1e293b" />
+                    <XAxis dataKey="month" tick={{ fill: '#64748b', fontSize: 11 }} />
+                    <YAxis tick={{ fill: '#64748b', fontSize: 11 }} tickFormatter={(v: number) => v >= 1000 ? `${(v / 1000).toFixed(0)}k` : String(v)} />
+                    <Tooltip
+                      contentStyle={{ background: '#0f172a', border: '1px solid #1e293b', borderRadius: 8 }}
+                      labelStyle={{ color: '#94a3b8', fontWeight: 700 }}
+                      formatter={(value: unknown, name: unknown) => [`${Number(value).toLocaleString()} tokens`, String(name ?? '')]}
+                    />
+                    <Legend wrapperStyle={{ color: '#64748b', fontSize: 11 }} />
+                    {models.map((model, i) => (
+                      <Bar key={model} dataKey={model} stackId="a" fill={getModelColor(model, i)} radius={i === models.length - 1 ? [4, 4, 0, 0] : [0, 0, 0, 0]} />
+                    ))}
+                  </BarChart>
+                </ResponsiveContainer>
+              </div>
+            </section>
+          )}
+
           {/* Main Selected Report */}
           {selectedReview && (
             <section className="mb-20">

--- a/src/api/routers/analysis.py
+++ b/src/api/routers/analysis.py
@@ -11,6 +11,35 @@ from src.api.utils import get_db_path, get_config_dir, load_config, df_to_json_s
 
 router = APIRouter(prefix="/api", tags=["analysis"])
 
+@router.get("/analysis-history/usage-stats")
+async def get_usage_stats(months: int = 6):
+    """直近N ヶ月のAI使用量を月別・モデル別に集計して返す。"""
+    conn = None
+    try:
+        db_path = get_db_path()
+        conn = sqlite3.connect(db_path)
+        query = """
+            SELECT
+                strftime('%Y-%m', created_at) AS month,
+                COALESCE(model_name, 'unknown') AS model,
+                COUNT(*) AS count,
+                SUM(COALESCE(total_tokens, 0)) AS total_tokens,
+                SUM(COALESCE(prompt_tokens, 0)) AS prompt_tokens,
+                SUM(COALESCE(response_tokens, 0)) AS response_tokens
+            FROM analysis_history
+            WHERE created_at >= date('now', ?)
+            GROUP BY month, model
+            ORDER BY month ASC, total_tokens DESC
+        """
+        since = f"-{months} months"
+        df = pd.read_sql_query(query, conn, params=(since,))
+        return df_to_json_safe_dict(df)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+    finally:
+        if conn:
+            conn.close()
+
 @router.get("/analysis-history")
 async def get_analysis_history(timeframe: str = "monthly"):
     conn = None


### PR DESCRIPTION
## Summary
- `/api/analysis-history/usage-stats` エンドポイントを追加（直近N ヶ月のモデル別トークン使用量を集計）
- AI Review ページの上部に「Model Usage」セクションを追加
  - 月別・モデル別のスタックバーチャート（Recharts）
  - 合計トークン数・分析件数のサマリー表示
  - モデルごとに固定カラー割り当て（gemini-2.0-flash → インジゴ等）
- `UsageStat` 型を `client.ts` に追加

## Test plan
- [ ] ビルドが成功すること（TypeScript エラーなし）
- [ ] フロントエンドテスト5ファイル・13件がパスすること
- [ ] バックエンドテスト全件がパスすること
- [ ] `/api/analysis-history/usage-stats` が正常なJSONを返すこと
- [ ] AI Review ページに月別トークン使用量チャートが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)